### PR TITLE
Fix default delegate value in TableRow

### DIFF
--- a/scalafx/src/main/scala/scalafx/scene/control/TableRow.scala
+++ b/scalafx/src/main/scala/scalafx/scene/control/TableRow.scala
@@ -37,7 +37,7 @@ object TableRow {
 /**
  * Wraps [[http://docs.oracle.com/javase/8/javafx/api/javafx/scene/control/TableRow.html]].
  */
-class TableRow[T](override val delegate: jfxsc.TableRow[T] = new jfxsc.TableRow)
+class TableRow[T](override val delegate: jfxsc.TableRow[T] = new jfxsc.TableRow[T])
   extends IndexedCell[T]
   with SFXDelegate[jfxsc.TableRow[T]] {
 


### PR DESCRIPTION
Since javafx TableRow is invariant on type parameter
