### PR TITLE
Fix default argument in TableRow constructor

### DIFF
--- a/scalafx/src/main/scala/scalafx/scene/control/TableRow.scala
+++ b/scalafx/src/main/scala/scalafx/scene/control/TableRow.scala
@@ -36,7 +36,7 @@ object TableRow {
 /**
  * Wraps [[http://docs.oracle.com/javafx/2/api/javafx/scene/control/TableRow.html]].
  */
-class TableRow[T](override val delegate: jfxsc.TableRow[T] = new jfxsc.TableRow)
+class TableRow[T](override val delegate: jfxsc.TableRow[T] = new jfxsc.TableRow[T])
   extends IndexedCell[T]
   with SFXDelegate[jfxsc.TableRow[T]] {
 


### PR DESCRIPTION
Add type parameter to default constructor angument in scalafx.scene.control.TableRow constructor, which otherwise resolved to jfxsc.TableRow[Nothing], causing type error:

```
scala> new scalafx.scene.control.TableRow[String]
<console>:8: error: type mismatch;
 found   : javafx.scene.control.TableRow[Nothing]
 required: javafx.scene.control.TableRow[String]
Note: Nothing <: String, but Java-defined class TableRow is invariant in type T.
You may wish to investigate a wildcard type such as `_ <: String`. (SLS 3.2.10)
Error occurred in an application involving default arguments.
              new scalafx.scene.control.TableRow[String]
              ^
```
