### PR TITLE
Fix TableView's columnResizePolicy and rowFactory

### DIFF
--- a/scalafx/src/main/scala/scalafx/scene/control/TableView.scala
+++ b/scalafx/src/main/scala/scalafx/scene/control/TableView.scala
@@ -29,6 +29,7 @@ package scalafx.scene.control
 import javafx.{collections => jfxc}
 import javafx.{ scene => jfxs }
 import javafx.scene.{ control => jfxsc }
+import javafx.{util => jfxu}
 import scalafx.Includes._
 import scalafx.beans.property.BooleanProperty
 import scalafx.beans.property.ObjectProperty
@@ -246,8 +247,12 @@ class TableView[S](override val delegate: jfxsc.TableView[S] = new jfxsc.TableVi
    */
   def columnResizePolicy: ObjectProperty[TableView.ResizeFeatures[S] => Boolean] =
     ObjectProperty((features: TableView.ResizeFeatures[S]) => delegate.columnResizePolicyProperty.value.call(features))
-  def columnResizePolicy_=(v: TableView.ResizeFeatures[S] => Boolean) {
-    columnResizePolicy() = v
+  def columnResizePolicy_=(p: TableView.ResizeFeatures[_] => Boolean) {
+    delegate.columnResizePolicyProperty().setValue(new jfxu.Callback[jfxsc.TableView.ResizeFeatures[_], java.lang.Boolean] {
+      def call(v: jfxsc.TableView.ResizeFeatures[_]): java.lang.Boolean = {
+        p(v)
+      }
+    })
   }
 
   /**
@@ -294,7 +299,11 @@ class TableView[S](override val delegate: jfxsc.TableView[S] = new jfxsc.TableVi
   def rowFactory: ObjectProperty[TableView[S] => TableRow[S]] =
     ObjectProperty((view: TableView[S]) => delegate.rowFactoryProperty.value.call(view))
   def rowFactory_=(factory: TableView[S] => TableRow[S]) {
-    rowFactory() = factory
+    delegate.rowFactoryProperty.setValue(new jfxu.Callback[jfxsc.TableView[S], jfxsc.TableRow[S]] {
+      def call(v: jfxsc.TableView[S]): jfxsc.TableRow[S] = {
+        factory(v)
+      }
+    })
   }
 
   /**


### PR DESCRIPTION
Fix erroneous implementation of assignment to columnResizePolicy and
rowFactory in TableView (copied it from TableColumn's cellFactory).
Previous version was effectively throwing the value away.
