### PR TITLE
Ability to show directory and file chooser without an owner window

### DIFF
--- a/scalafx/src/main/scala/scalafx/stage/DirectoryChooser.scala
+++ b/scalafx/src/main/scala/scalafx/stage/DirectoryChooser.scala
@@ -61,4 +61,9 @@ class DirectoryChooser(override val delegate: jfxs.DirectoryChooser = new jfxs.D
    * Shows a new directory selection dialog.
    */
   def showDialog(ownerWindow: Window): File = delegate.showDialog(ownerWindow)
+
+  /**
+   * Shows a new directory selection dialog.
+   */
+  def showDialog(): File = delegate.showDialog(null)
 }

--- a/scalafx/src/main/scala/scalafx/stage/FileChooser.scala
+++ b/scalafx/src/main/scala/scalafx/stage/FileChooser.scala
@@ -117,13 +117,28 @@ class FileChooser(override val delegate: jfxs.FileChooser = new jfxs.FileChooser
   def showOpenDialog(ownerWindow: Window): File = delegate.showOpenDialog(ownerWindow)
 
   /**
+   * Shows a new file open dialog.
+   */
+  def showOpenDialog(): File = delegate.showOpenDialog(null)
+
+  /**
    * Shows a new file open dialog in which multiple files can be selected.
    */
   def showOpenMultipleDialog(ownerWindow: Window): Seq[File] = delegate.showOpenMultipleDialog(ownerWindow)
 
   /**
+   * Shows a new file open dialog in which multiple files can be selected.
+   */
+  def showOpenMultipleDialog(): Seq[File] = delegate.showOpenMultipleDialog(null)
+
+  /**
    * Shows a new file save dialog.
    */
   def showSaveDialog(ownerWindow: Window): File = delegate.showSaveDialog(ownerWindow)
+
+  /**
+   * Shows a new file save dialog.
+   */
+  def showSaveDialog(): File = delegate.showSaveDialog(null)
 
 }


### PR DESCRIPTION
Variants of `showDialog` without requiring an owner window. The original wrappers cannot be used like this because of

```
    java.lang.NullPointerException
    at scalafx.stage.Window$.sfxWindow2jfx(Window.scala:41)
```
