### PR TITLE
Add SeparatorMenuItem and CustomMenuItem

### DIFF
--- a/scalafx-demos/src/main/scala/scalafx/controls/MenuTest.scala
+++ b/scalafx-demos/src/main/scala/scalafx/controls/MenuTest.scala
@@ -32,7 +32,7 @@ import scalafx.application.JFXApp
 import scalafx.application.JFXApp.PrimaryStage
 import scalafx.event.ActionEvent
 import scalafx.scene.Scene
-import scalafx.scene.control.{Label, Menu, MenuBar, MenuItem}
+import scalafx.scene.control.{Label, Menu, MenuBar, MenuItem, SeparatorMenuItem}
 import scalafx.scene.layout.{BorderPane, VBox}
 import scalafx.scene.paint.Color
 
@@ -44,6 +44,7 @@ object MenuTest extends JFXApp {
       new MenuItem("Open") {
         onAction = (ae: ActionEvent) => history.children += new Label("Selected item `Open`")
       },
+      new SeparatorMenuItem,
       new MenuItem("Close") {
         onAction = (ae: ActionEvent) => history.children += new Label("Selected item `Close`")
       }
@@ -79,4 +80,5 @@ object MenuTest extends JFXApp {
   def printEvent(eventStr: String)() {
     history.children += new Label(eventStr)
   }
+
 }

--- a/scalafx/src/main/scala/scalafx/scene/control/ControlIncludes.scala
+++ b/scalafx/src/main/scala/scalafx/scene/control/ControlIncludes.scala
@@ -64,6 +64,7 @@ object ControlIncludes extends ControlIncludes
  * @define CEBX CheckBox
  * @define CUMIT CustomMenuItem
  * @define CMNIT CheckMenuItem
+ * @define SPMIT SeparatorMenuItem
  * @define CTDP ContentDisplay
  * @define CTMN ContextMenu
  * @define CTRL Control
@@ -382,6 +383,14 @@ trait ControlIncludes
    * @return $SFX $CUMIT
    */
   implicit def jfxCustomMenuItem2sfx(c: jfxsc.CustomMenuItem): CustomMenuItem = if(c != null) new CustomMenuItem(c) else null
+
+  /**
+   * $START$SPMIT.html $SPMIT$END
+   *
+   * @param s $JFX $SPMIT
+   * @return $SFX $SPMIT
+   */
+  implicit def jfxSeparatorMenuItem2sfx(s: jfxsc.SeparatorMenuItem): SeparatorMenuItem = if(s != null) new SeparatorMenuItem(s) else null
 
   /**
    * $START$MSMD.html $MSMD$END

--- a/scalafx/src/main/scala/scalafx/scene/control/ControlIncludes.scala
+++ b/scalafx/src/main/scala/scalafx/scene/control/ControlIncludes.scala
@@ -62,6 +62,7 @@ object ControlIncludes extends ControlIncludes
  * @define CELL Cell
  * @define CHBX ChoiceBox
  * @define CEBX CheckBox
+ * @define CUMIT CustomMenuItem
  * @define CMNIT CheckMenuItem
  * @define CTDP ContentDisplay
  * @define CTMN ContextMenu
@@ -373,6 +374,14 @@ trait ControlIncludes
    * @return $SFX $MNIT
    */
   implicit def jfxMenuItem2sfx(m: jfxsc.MenuItem): MenuItem = if (m != null) new MenuItem(m) else null
+
+  /**
+   * $START$CUMIT.html $CUMIT$END
+   *
+   * @param c $JFX $CUMIT
+   * @return $SFX $CUMIT
+   */
+  implicit def jfxCustomMenuItem2sfx(c: jfxsc.CustomMenuItem): CustomMenuItem = if(c != null) new CustomMenuItem(c) else null
 
   /**
    * $START$MSMD.html $MSMD$END

--- a/scalafx/src/main/scala/scalafx/scene/control/CustomMenuItem.scala
+++ b/scalafx/src/main/scala/scalafx/scene/control/CustomMenuItem.scala
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2011-2014, ScalaFX Project
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the ScalaFX Project nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE SCALAFX PROJECT OR ITS CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package scalafx.scene.control
+
+import javafx.scene.{control => jfxsc}
+import javafx.{scene => jfxs}
+
+import scala.language.implicitConversions
+
+import scalafx.beans.property.{BooleanProperty, ObjectProperty}
+import scalafx.delegate.SFXDelegate
+import scalafx.Includes._
+import scalafx.scene.Node
+
+/** @author Roman Hargrave */
+object CustomMenuItem {
+    implicit def sfxCustomMenuItem2jfx(c: CustomMenuItem): jfxsc.CustomMenuItem = if(c != null) c.delegate else null
+}
+class CustomMenuItem(override val delegate: jfxsc.CustomMenuItem = new jfxsc.CustomMenuItem) extends MenuItem with SFXDelegate[jfxsc.CustomMenuItem] {
+
+    /**
+     * Bridge constructor for [[jfxsc.CustomMenuItem(Node)]]
+     * @param content menu item content
+     */
+    def this(content: Node) = this(new jfxsc.CustomMenuItem(content))
+
+    /**
+     * Bridge constructor for [[jfxsc.CustomMenuItem(Node, boolean)]]
+     * @param content menu item content
+     * @param hidOnClick hide on click
+     */
+    def this(content: Node, hidOnClick: Boolean) = this(new jfxsc.CustomMenuItem)
+
+    def content: ObjectProperty[jfxs.Node] = delegate.contentProperty()
+    def content_=(n: Node): Unit = {
+        content() = n
+    }
+
+    def hideOnClick: BooleanProperty = delegate.hideOnClickProperty()
+    def hideOnClick_=(b: Boolean): Unit = {
+        hideOnClick() = b
+    }
+}

--- a/scalafx/src/main/scala/scalafx/scene/control/SeparatorMenuItem.scala
+++ b/scalafx/src/main/scala/scalafx/scene/control/SeparatorMenuItem.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2011-2014, ScalaFX Project
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the ScalaFX Project nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE SCALAFX PROJECT OR ITS CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package scalafx.scene.control
+
+import javafx.scene.{control => jfxsc}
+
+import scala.language.implicitConversions
+
+import scalafx.delegate.SFXDelegate
+
+/** @author Roman Hargrave */
+object SeparatorMenuItem {
+    implicit def sfxSeparatorMenuItem2jfx(s: SeparatorMenuItem): jfxsc.SeparatorMenuItem = if(s != null) s.delegate else null
+}
+
+class SeparatorMenuItem(override val delegate: jfxsc.SeparatorMenuItem) extends CustomMenuItem with SFXDelegate[jfxsc.SeparatorMenuItem] {
+    def this() = {
+        this(new SeparatorMenuItem)
+    }
+}

--- a/scalafx/src/main/scala/scalafx/scene/control/SeparatorMenuItem.scala
+++ b/scalafx/src/main/scala/scalafx/scene/control/SeparatorMenuItem.scala
@@ -40,6 +40,6 @@ object SeparatorMenuItem {
 
 class SeparatorMenuItem(override val delegate: jfxsc.SeparatorMenuItem) extends CustomMenuItem with SFXDelegate[jfxsc.SeparatorMenuItem] {
     def this() = {
-        this(new SeparatorMenuItem)
+        this(new jfxsc.SeparatorMenuItem)
     }
 }

--- a/scalafx/src/test/scala/scalafx/scene/control/CustomMenuItemSpec.scala
+++ b/scalafx/src/test/scala/scalafx/scene/control/CustomMenuItemSpec.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2011-2014, ScalaFX Project
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the ScalaFX Project nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE SCALAFX PROJECT OR ITS CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package scalafx.scene.control
+
+import javafx.scene.{control => jfxsc}
+
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+
+import scalafx.Includes._
+import scalafx.testutil.AbstractSFXDelegateSpec
+
+/**
+ * CustomMenuItem Spec tests.
+ *
+ *
+ */
+@RunWith(classOf[JUnitRunner])
+class CustomMenuItemSpec
+  extends AbstractSFXDelegateSpec[jfxsc.CustomMenuItem, CustomMenuItem, jfxsc.CustomMenuItemBuilder[_]](classOf[jfxsc.CustomMenuItem], classOf[CustomMenuItem], classOf[jfxsc.CustomMenuItemBuilder[_]])

--- a/scalafx/src/test/scala/scalafx/scene/control/SeparatorMenuItemSpec.scala
+++ b/scalafx/src/test/scala/scalafx/scene/control/SeparatorMenuItemSpec.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2011-2014, ScalaFX Project
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the ScalaFX Project nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE SCALAFX PROJECT OR ITS CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package scalafx.scene.control
+
+import javafx.scene.{control => jfxsc}
+
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+
+import scalafx.Includes._
+import scalafx.testutil.AbstractSFXDelegateSpec
+
+/**
+ * SeparatorMenuItem Spec tests.
+ *
+ *
+ */
+@RunWith(classOf[JUnitRunner])
+class SeparatorMenuItemSpec
+  extends AbstractSFXDelegateSpec[jfxsc.SeparatorMenuItem, SeparatorMenuItem, jfxsc.SeparatorMenuItemBuilder[_]](classOf[jfxsc.SeparatorMenuItem], classOf[SeparatorMenuItem], classOf[jfxsc.SeparatorMenuItemBuilder[_]])
+


### PR DESCRIPTION
Add CustomMenuItem and SeparatorMenuItem to ScalaFX 2. Also added the SeparatorMenuItem to the demo, and confirmed working.

These modifications were made regarding #173 