### PR TITLE
Fixes #190: Convenience methods for clipboard assignment don't work

### DIFF
--- a/scalafx/src/main/scala/scalafx/scene/input/Clipboard.scala
+++ b/scalafx/src/main/scala/scalafx/scene/input/Clipboard.scala
@@ -56,9 +56,20 @@ class Clipboard(override val delegate: jfxsi.Clipboard) extends SFXDelegate[jfxs
   }
 
   /**
-   * Returns the content stored in this clipboard of the given type, or null if there is no content with this type.
+   * Returns the content stored in this clipboard
    */
-  def content(dataFormat: DataFormat) = delegate.getContent(dataFormat)
+  def content = {
+    val cnt = new ClipboardContent()
+
+    contentTypes foreach (cnt.put(_, delegate.getContent(_)))
+
+    cnt
+  }
+
+  /**
+   * Returns the content stored in this clipboard of the given type, if any
+   */
+  def get(dataFormat: DataFormat) = Option(delegate.getContent(dataFormat))
 
   /**
    * Gets the set of DataFormat types on this Clipboard instance which have associated data registered on the clipboard.

--- a/scalafx/src/main/scala/scalafx/scene/input/Clipboard.scala
+++ b/scalafx/src/main/scala/scalafx/scene/input/Clipboard.scala
@@ -61,7 +61,9 @@ class Clipboard(override val delegate: jfxsi.Clipboard) extends SFXDelegate[jfxs
   def content = {
     val cnt = new ClipboardContent()
 
-    contentTypes foreach (cnt.put(_, delegate.getContent(_)))
+    contentTypes foreach { jfxDataFormat =>
+      cnt.put(new DataFormat(jfxDataFormat), delegate.getContent(jfxDataFormat))
+    }
 
     cnt
   }

--- a/scalafx/src/main/scala/scalafx/scene/input/Clipboard.scala
+++ b/scalafx/src/main/scala/scalafx/scene/input/Clipboard.scala
@@ -61,8 +61,8 @@ class Clipboard(override val delegate: jfxsi.Clipboard) extends SFXDelegate[jfxs
   def content = {
     val cnt = new ClipboardContent()
 
-    contentTypes foreach { jfxDataFormat =>
-      cnt.put(new DataFormat(jfxDataFormat), delegate.getContent(jfxDataFormat))
+    contentTypes foreach { dataFormat =>
+      cnt.put(dataFormat, delegate.getContent(dataFormat))
     }
 
     cnt
@@ -76,7 +76,7 @@ class Clipboard(override val delegate: jfxsi.Clipboard) extends SFXDelegate[jfxs
   /**
    * Gets the set of DataFormat types on this Clipboard instance which have associated data registered on the clipboard.
    */
-  def contentTypes: Set[jfxsi.DataFormat] = delegate.getContentTypes
+  def contentTypes: Set[DataFormat] = delegate.getContentTypes map (new DataFormat(_))
 
   /**
    * Gets the list of files from the clipboard which had previously been registered.

--- a/scalafx/src/main/scala/scalafx/scene/input/DataFormat.scala
+++ b/scalafx/src/main/scala/scalafx/scene/input/DataFormat.scala
@@ -45,32 +45,32 @@ object DataFormat {
   /**
    * Represents a List of Files.
    */
-  val Files = jfxsi.DataFormat.FILES
+  val Files: DataFormat = new DataFormat(jfxsi.DataFormat.FILES)
 
   /**
    * Represents an HTML formatted string.
    */
-  val Html = jfxsi.DataFormat.HTML
+  val Html: DataFormat = new DataFormat(jfxsi.DataFormat.HTML)
 
   /**
    * A special platform specific image type, such as is commonly used on the clipboard and interoperates widely with other applications.
    */
-  val Image = jfxsi.DataFormat.IMAGE
+  val Image: DataFormat = new DataFormat(jfxsi.DataFormat.IMAGE)
 
   /**
    * Represents a plain text string.
    */
-  val PlainText = jfxsi.DataFormat.PLAIN_TEXT
+  val PlainText: DataFormat = new DataFormat(jfxsi.DataFormat.PLAIN_TEXT)
 
   /**
    * Represents an RTF formatted string
    */
-  val Rtf = jfxsi.DataFormat.RTF
+  val Rtf: DataFormat = new DataFormat(jfxsi.DataFormat.RTF)
 
   /**
    * Represents a URL, encoded as a String
    */
-  val Url = jfxsi.DataFormat.URL
+  val Url: DataFormat = new DataFormat(jfxsi.DataFormat.URL)
 
 }
 

--- a/scalafx/src/test/scala/issues/issue190/Issue190Spec.scala
+++ b/scalafx/src/test/scala/issues/issue190/Issue190Spec.scala
@@ -1,0 +1,22 @@
+package issues.issue190
+
+import java.io.File
+
+import scalafx.scene.input.{DataFormat, ClipboardContent, Clipboard}
+
+import org.junit.runner.RunWith
+import org.scalatest.FlatSpec
+import org.scalatest.junit.JUnitRunner
+
+/** Issue 190: Convenience methods not working for clipboard */
+@RunWith(classOf[JUnitRunner])
+class Issue190Spec extends FlatSpec {
+  "ClipboardContent" should "be assignable to the content of the clipboard" in {
+    Clipboard.systemClipboard.content = new ClipboardContent()
+  }
+
+  "A Map" should "be assignable to the content of the clipboard" in {
+    val files = List(new File("Test"))
+    Clipboard.systemClipboard.content = Map(new DataFormat("Files") -> files)
+  }
+}


### PR DESCRIPTION
Because convenience methods such as `content_=` require a method without
the `_=` as part of the name, I've modified content to return all the
data on clipboard as `ClipboardContent`.

The individual `getContent` method from JavaFX has been renamed to get,
and optionally returns an object for the given data format, instead of
returning null, in order to be null-safe.