### PR TITLE
Feature/direct lambda assignment for event handlers

### DIFF
--- a/scalafx-demos/src/main/scala/scalafx/VanishingCircles.scala
+++ b/scalafx-demos/src/main/scala/scalafx/VanishingCircles.scala
@@ -61,7 +61,7 @@ object VanishingCircles extends JFXApp {
         strokeWidth <== when(hover) choose 4 otherwise 0
         stroke = White
         // add this for event listeners:
-        onMouseClicked = handle {
+        onMouseClicked = { mouseEvent =>
           Timeline(at(3 s) {radius -> 0}).play()
         }
       }

--- a/scalafx-demos/src/main/scala/scalafx/VanishingCircles.scala
+++ b/scalafx-demos/src/main/scala/scalafx/VanishingCircles.scala
@@ -36,6 +36,7 @@ import scalafx.application.JFXApp
 import scalafx.application.JFXApp.PrimaryStage
 import scalafx.scene.Scene
 import scalafx.scene.effect.BoxBlur
+import scalafx.scene.input.MouseEvent
 import scalafx.scene.paint.Color._
 import scalafx.scene.shape.Circle
 
@@ -61,7 +62,7 @@ object VanishingCircles extends JFXApp {
         strokeWidth <== when(hover) choose 4 otherwise 0
         stroke = White
         // add this for event listeners:
-        onMouseClicked = { mouseEvent =>
+        onMouseClicked = { mouseEvent: MouseEvent =>
           Timeline(at(3 s) {radius -> 0}).play()
         }
       }

--- a/scalafx-demos/src/main/scala/scalafx/WebDemo.scala
+++ b/scalafx-demos/src/main/scala/scalafx/WebDemo.scala
@@ -55,7 +55,7 @@ object WebDemo extends JFXApp {
     hgrow = Priority.Always
     vgrow = Priority.Never
   }
-  txfUrl.onAction = handle {engine.load(txfUrl.text.get)}
+  txfUrl.onAction = { actionEvent => engine.load(txfUrl.text.get)}
 
   stage = new PrimaryStage {
     title = "ScalaFX Web Demo"

--- a/scalafx-demos/src/main/scala/scalafx/WebDemo.scala
+++ b/scalafx-demos/src/main/scala/scalafx/WebDemo.scala
@@ -29,6 +29,7 @@ package scalafx
 import scalafx.Includes._
 import scalafx.application.JFXApp
 import scalafx.application.JFXApp.PrimaryStage
+import scalafx.event.ActionEvent
 import scalafx.scene.Scene
 import scalafx.scene.control._
 import scalafx.scene.layout._
@@ -55,7 +56,7 @@ object WebDemo extends JFXApp {
     hgrow = Priority.Always
     vgrow = Priority.Never
   }
-  txfUrl.onAction = { actionEvent => engine.load(txfUrl.text.get)}
+  txfUrl.onAction = { actionEvent: ActionEvent => engine.load(txfUrl.text.get)}
 
   stage = new PrimaryStage {
     title = "ScalaFX Web Demo"

--- a/scalafx-demos/src/main/scala/scalafx/colorselector/SliderControlDemo.scala
+++ b/scalafx-demos/src/main/scala/scalafx/colorselector/SliderControlDemo.scala
@@ -46,7 +46,7 @@ object SliderControlDemo extends JFXApp {
     alignmentInParent = Pos.BaselineLeft
     promptText = "Enter the value"
     hgrow = Priority.Never
-    onAction = handle {
+    onAction =  { actionEvent =>
       sliderControl.value = text.get.toDouble
     }
   }

--- a/scalafx-demos/src/main/scala/scalafx/colorselector/SliderControlDemo.scala
+++ b/scalafx-demos/src/main/scala/scalafx/colorselector/SliderControlDemo.scala
@@ -30,6 +30,7 @@ package scalafx.colorselector
 import scalafx.Includes._
 import scalafx.application.JFXApp
 import scalafx.application.JFXApp.PrimaryStage
+import scalafx.event.ActionEvent
 import scalafx.geometry.{HPos, Pos, VPos}
 import scalafx.scene.Scene
 import scalafx.scene.control.{CheckBox, Label, TextField}
@@ -46,7 +47,7 @@ object SliderControlDemo extends JFXApp {
     alignmentInParent = Pos.BaselineLeft
     promptText = "Enter the value"
     hgrow = Priority.Never
-    onAction =  { actionEvent =>
+    onAction =  { actionEvent: ActionEvent =>
       sliderControl.value = text.get.toDouble
     }
   }

--- a/scalafx-demos/src/main/scala/scalafx/controls/CheckBoxTest.scala
+++ b/scalafx-demos/src/main/scala/scalafx/controls/CheckBoxTest.scala
@@ -88,7 +88,7 @@ class CheckBoxControls(check: CheckBox) extends PropertiesNodes[CheckBox](check,
 
   val btnFire = new Button {
     text = "Fire!"
-    onAction = handle {check.fire()}
+    onAction = { actionEvent => check.fire() }
   }
 
   val txfText = new TextField {

--- a/scalafx-demos/src/main/scala/scalafx/controls/CheckBoxTest.scala
+++ b/scalafx-demos/src/main/scala/scalafx/controls/CheckBoxTest.scala
@@ -88,7 +88,7 @@ class CheckBoxControls(check: CheckBox) extends PropertiesNodes[CheckBox](check,
 
   val btnFire = new Button {
     text = "Fire!"
-    onAction = { actionEvent => check.fire() }
+    onAction = { actionEvent: ActionEvent => check.fire() }
   }
 
   val txfText = new TextField {

--- a/scalafx-demos/src/main/scala/scalafx/controls/DialogsDemo.scala
+++ b/scalafx-demos/src/main/scala/scalafx/controls/DialogsDemo.scala
@@ -70,7 +70,7 @@ object DialogsDemo extends JFXApp {
   }
 
   def button[R](text: String, action: () => R) = new Button(text) {
-    onAction = handle {action()}
+    onAction = { actionEvent => action() }
     alignmentInParent = Pos.Center
     hgrow = Priority.Always
     maxWidth = Double.MaxValue

--- a/scalafx-demos/src/main/scala/scalafx/controls/DialogsDemo.scala
+++ b/scalafx-demos/src/main/scala/scalafx/controls/DialogsDemo.scala
@@ -33,6 +33,7 @@ import scala.language.implicitConversions
 import scalafx.Includes._
 import scalafx.application.JFXApp
 import scalafx.application.JFXApp.PrimaryStage
+import scalafx.event.ActionEvent
 import scalafx.geometry.{Insets, Pos}
 import scalafx.scene.Scene
 import scalafx.scene.control.Alert.AlertType
@@ -70,7 +71,7 @@ object DialogsDemo extends JFXApp {
   }
 
   def button[R](text: String, action: () => R) = new Button(text) {
-    onAction = { actionEvent => action() }
+    onAction = { actionEvent: ActionEvent => action() }
     alignmentInParent = Pos.Center
     hgrow = Priority.Always
     maxWidth = Double.MaxValue

--- a/scalafx-demos/src/main/scala/scalafx/controls/LoginDialogDemo.scala
+++ b/scalafx-demos/src/main/scala/scalafx/controls/LoginDialogDemo.scala
@@ -44,7 +44,7 @@ object LoginDialogDemo extends JFXApp {
       title = "Custom Dialog Demo"
       content = new VBox {
         children = new Button("Show Login Dialog") {
-          onAction = handle {onShowLoginDialog()}
+          onAction = { actionEvent => onShowLoginDialog() }
         }
         padding = Insets(top = 24, right = 64, bottom = 24, left = 64)
       }

--- a/scalafx-demos/src/main/scala/scalafx/controls/LoginDialogDemo.scala
+++ b/scalafx-demos/src/main/scala/scalafx/controls/LoginDialogDemo.scala
@@ -29,6 +29,7 @@ package scalafx.controls
 
 import scalafx.Includes._
 import scalafx.application.{JFXApp, Platform}
+import scalafx.event.ActionEvent
 import scalafx.geometry.Insets
 import scalafx.scene.Scene
 import scalafx.scene.control.ButtonBar.ButtonData
@@ -44,7 +45,7 @@ object LoginDialogDemo extends JFXApp {
       title = "Custom Dialog Demo"
       content = new VBox {
         children = new Button("Show Login Dialog") {
-          onAction = { actionEvent => onShowLoginDialog() }
+          onAction = { actionEvent: ActionEvent => onShowLoginDialog() }
         }
         padding = Insets(top = 24, right = 64, bottom = 24, left = 64)
       }

--- a/scalafx-demos/src/main/scala/scalafx/controls/MenuTest.scala
+++ b/scalafx-demos/src/main/scala/scalafx/controls/MenuTest.scala
@@ -30,7 +30,7 @@ package scalafx.controls
 import scalafx.Includes._
 import scalafx.application.JFXApp
 import scalafx.application.JFXApp.PrimaryStage
-import scalafx.event.ActionEvent
+import scalafx.event.{Event, ActionEvent}
 import scalafx.scene.Scene
 import scalafx.scene.control.{Label, Menu, MenuBar, MenuItem, SeparatorMenuItem}
 import scalafx.scene.layout.{BorderPane, VBox}
@@ -50,10 +50,10 @@ object MenuTest extends JFXApp {
       }
     )
 
-    onShowing = { evt => printEvent("on showing") }
-    onShown = { evt => printEvent("on shown") }
-    onHiding = { evt => printEvent("on hiding") }
-    onHidden = { evt => printEvent("on hidden") }
+    onShowing = { evt: Event => printEvent("on showing") }
+    onShown = { evt: Event => printEvent("on shown") }
+    onHiding = { evt: Event => printEvent("on hiding") }
+    onHidden = { evt: Event => printEvent("on hidden") }
   }
 
   val history = new VBox()

--- a/scalafx-demos/src/main/scala/scalafx/controls/MenuTest.scala
+++ b/scalafx-demos/src/main/scala/scalafx/controls/MenuTest.scala
@@ -50,10 +50,10 @@ object MenuTest extends JFXApp {
       }
     )
 
-    onShowing = handle {printEvent("on showing")}
-    onShown = handle {printEvent("on shown")}
-    onHiding = handle {printEvent("on hiding")}
-    onHidden = handle {printEvent("on hidden")}
+    onShowing = { evt => printEvent("on showing") }
+    onShown = { evt => printEvent("on shown") }
+    onHiding = { evt => printEvent("on hiding") }
+    onHidden = { evt => printEvent("on hidden") }
   }
 
   val history = new VBox()

--- a/scalafx-demos/src/main/scala/scalafx/controls/PasswordFieldTest.scala
+++ b/scalafx-demos/src/main/scala/scalafx/controls/PasswordFieldTest.scala
@@ -82,12 +82,12 @@ class PasswordFieldControls(target: PasswordField) extends PropertiesNodes[Passw
    */
   val btnCopy = new Button {
     text = "Copy"
-    onAction = handle {target.copy()}
+    onAction = { actionEvent => target.copy() }
   }
 
   val btnCut = new Button {
     text = "Cut"
-    onAction = handle {target.cut()}
+    onAction = { actionEvent => target.cut() }
   }
 
   super.addNode("Typed Text", lblText)

--- a/scalafx-demos/src/main/scala/scalafx/controls/PasswordFieldTest.scala
+++ b/scalafx-demos/src/main/scala/scalafx/controls/PasswordFieldTest.scala
@@ -31,6 +31,7 @@ import scalafx.Includes._
 import scalafx.application.JFXApp
 import scalafx.application.JFXApp.PrimaryStage
 import scalafx.controls.controls.{ControlControls, PropertiesNodes, TextFieldControls, TextInputControlControls}
+import scalafx.event.ActionEvent
 import scalafx.geometry.Pos
 import scalafx.scene.Scene
 import scalafx.scene.control.{Button, Label, PasswordField}
@@ -82,12 +83,12 @@ class PasswordFieldControls(target: PasswordField) extends PropertiesNodes[Passw
    */
   val btnCopy = new Button {
     text = "Copy"
-    onAction = { actionEvent => target.copy() }
+    onAction = { actionEvent: ActionEvent => target.copy() }
   }
 
   val btnCut = new Button {
     text = "Cut"
-    onAction = { actionEvent => target.cut() }
+    onAction = { actionEvent: ActionEvent => target.cut() }
   }
 
   super.addNode("Typed Text", lblText)

--- a/scalafx-demos/src/main/scala/scalafx/controls/SliderTest.scala
+++ b/scalafx-demos/src/main/scala/scalafx/controls/SliderTest.scala
@@ -93,14 +93,14 @@ class SliderControls(target: Slider) extends PropertiesNodes[Slider](target, "Sl
   val originalValue = target.value.get
   val txfValue = new TextField
   target.value.onChange(txfValue.text = target.value.get.toString)
-  txfValue.onAction = handle {super.fillDoublePropertyFromText(target.value, txfValue, false)}
+  txfValue.onAction = { actionEvent => super.fillDoublePropertyFromText(target.value, txfValue, false) }
 
   val originalBlockIncrement = target.blockIncrement.get
   val txfBlockIncrement = new TextField {
     text = originalBlockIncrement.get.toString
   }
   target.blockIncrement.onChange(txfBlockIncrement.text = target.blockIncrement.get.toString)
-  txfBlockIncrement.onAction = handle {fillDoublePropertyFromText(target.blockIncrement, txfBlockIncrement, false)}
+  txfBlockIncrement.onAction = { actionEvent => fillDoublePropertyFromText(target.blockIncrement, txfBlockIncrement, false) }
 
   val txfLabelFormatter = new TextField
   txfLabelFormatter.text.onChange(
@@ -115,28 +115,28 @@ class SliderControls(target: Slider) extends PropertiesNodes[Slider](target, "Sl
     text = originalMajorTickUnit.toString
   }
   target.majorTickUnit.onChange(txfMajorTickUnit.text = target.majorTickUnit.get.toString)
-  txfMajorTickUnit.onAction = handle {fillDoublePropertyFromText(target.majorTickUnit, txfMajorTickUnit, false)}
+  txfMajorTickUnit.onAction = { actionEvent => fillDoublePropertyFromText(target.majorTickUnit, txfMajorTickUnit, false) }
 
   val originalMax = target.max.get()
   val txfMax = new TextField {
     text = originalMax.toString
   }
   target.max.onChange(txfMax.text = target.max.get.toString)
-  txfMax.onAction = handle {fillDoublePropertyFromText(target.max, txfMax, false)}
+  txfMax.onAction = { actionEvent => fillDoublePropertyFromText(target.max, txfMax, false) }
 
   val originalMinorTickCount = target.minorTickCount.get()
   val txfMinorTickCount = new TextField {
     text = originalMinorTickCount.toString
   }
   target.minorTickCount.onChange(txfMinorTickCount.text = target.minorTickCount.get.toString)
-  txfMinorTickCount.onAction = handle {fillIntPropertyFromText(target.minorTickCount, txfMinorTickCount, false)}
+  txfMinorTickCount.onAction = { actionEvent => fillIntPropertyFromText(target.minorTickCount, txfMinorTickCount, false) }
 
   val originalMin = target.min.get()
   val txfMin = new TextField {
     text = originalMin.toString
   }
   target.min.onChange(txfMin.text = target.min.get.toString)
-  txfMin.onAction = handle {fillDoublePropertyFromText(target.min, txfMin, false)}
+  txfMin.onAction = { actionEvent => fillDoublePropertyFromText(target.min, txfMin, false) }
 
   val originalShowTickLabels = target.showTickLabels.get
   val chbShowTickLabels = new CheckBox {

--- a/scalafx-demos/src/main/scala/scalafx/controls/SliderTest.scala
+++ b/scalafx-demos/src/main/scala/scalafx/controls/SliderTest.scala
@@ -31,6 +31,7 @@ import scalafx.Includes._
 import scalafx.application.JFXApp
 import scalafx.application.JFXApp.PrimaryStage
 import scalafx.controls.controls.{PropertiesNodes, _}
+import scalafx.event.ActionEvent
 import scalafx.geometry.{Orientation, Pos}
 import scalafx.scene.Scene
 import scalafx.scene.control._
@@ -93,14 +94,14 @@ class SliderControls(target: Slider) extends PropertiesNodes[Slider](target, "Sl
   val originalValue = target.value.get
   val txfValue = new TextField
   target.value.onChange(txfValue.text = target.value.get.toString)
-  txfValue.onAction = { actionEvent => super.fillDoublePropertyFromText(target.value, txfValue, false) }
+  txfValue.onAction = { actionEvent: ActionEvent => super.fillDoublePropertyFromText(target.value, txfValue, false) }
 
   val originalBlockIncrement = target.blockIncrement.get
   val txfBlockIncrement = new TextField {
     text = originalBlockIncrement.get.toString
   }
   target.blockIncrement.onChange(txfBlockIncrement.text = target.blockIncrement.get.toString)
-  txfBlockIncrement.onAction = { actionEvent => fillDoublePropertyFromText(target.blockIncrement, txfBlockIncrement, false) }
+  txfBlockIncrement.onAction = { actionEvent: ActionEvent => fillDoublePropertyFromText(target.blockIncrement, txfBlockIncrement, false) }
 
   val txfLabelFormatter = new TextField
   txfLabelFormatter.text.onChange(
@@ -115,28 +116,28 @@ class SliderControls(target: Slider) extends PropertiesNodes[Slider](target, "Sl
     text = originalMajorTickUnit.toString
   }
   target.majorTickUnit.onChange(txfMajorTickUnit.text = target.majorTickUnit.get.toString)
-  txfMajorTickUnit.onAction = { actionEvent => fillDoublePropertyFromText(target.majorTickUnit, txfMajorTickUnit, false) }
+  txfMajorTickUnit.onAction = { actionEvent: ActionEvent => fillDoublePropertyFromText(target.majorTickUnit, txfMajorTickUnit, false) }
 
   val originalMax = target.max.get()
   val txfMax = new TextField {
     text = originalMax.toString
   }
   target.max.onChange(txfMax.text = target.max.get.toString)
-  txfMax.onAction = { actionEvent => fillDoublePropertyFromText(target.max, txfMax, false) }
+  txfMax.onAction = { actionEvent: ActionEvent => fillDoublePropertyFromText(target.max, txfMax, false) }
 
   val originalMinorTickCount = target.minorTickCount.get()
   val txfMinorTickCount = new TextField {
     text = originalMinorTickCount.toString
   }
   target.minorTickCount.onChange(txfMinorTickCount.text = target.minorTickCount.get.toString)
-  txfMinorTickCount.onAction = { actionEvent => fillIntPropertyFromText(target.minorTickCount, txfMinorTickCount, false) }
+  txfMinorTickCount.onAction = { actionEvent: ActionEvent => fillIntPropertyFromText(target.minorTickCount, txfMinorTickCount, false) }
 
   val originalMin = target.min.get()
   val txfMin = new TextField {
     text = originalMin.toString
   }
   target.min.onChange(txfMin.text = target.min.get.toString)
-  txfMin.onAction = { actionEvent => fillDoublePropertyFromText(target.min, txfMin, false) }
+  txfMin.onAction = { actionEvent: ActionEvent => fillDoublePropertyFromText(target.min, txfMin, false) }
 
   val originalShowTickLabels = target.showTickLabels.get
   val chbShowTickLabels = new CheckBox {

--- a/scalafx-demos/src/main/scala/scalafx/controls/controls/ComboBoxControls.scala
+++ b/scalafx-demos/src/main/scala/scalafx/controls/controls/ComboBoxControls.scala
@@ -49,16 +49,16 @@ class ComboBoxControls(target: ComboBox[String]) extends PropertiesNodes[ComboBo
   val txfVisibleRowCount = new TextField {
     text = target.visibleRowCount.get.toString
   }
-  txfVisibleRowCount.onAction = handle {  fillIntPropertyFromText(target.visibleRowCount, txfVisibleRowCount, false) }
+  txfVisibleRowCount.onAction = { actionEvent => fillIntPropertyFromText(target.visibleRowCount, txfVisibleRowCount, false) }
 
   val btnAddItem = new Button {
     text = "Add new Item"
-    onAction = handle { addNewTab() }
+    onAction = { actionEvent => addNewTab() }
   }
 
   val btnRemoveItem = new Button {
     text = "Remove Item"
-    onAction = handle { removeCurrentItem() }
+    onAction = { actionEvent => removeCurrentItem() }
   }
 
   super.addNode("Visible Rows", txfVisibleRowCount)

--- a/scalafx-demos/src/main/scala/scalafx/controls/controls/ComboBoxControls.scala
+++ b/scalafx-demos/src/main/scala/scalafx/controls/controls/ComboBoxControls.scala
@@ -28,6 +28,7 @@
 package scalafx.controls.controls
 
 import scalafx.Includes._
+import scalafx.event.ActionEvent
 import scalafx.scene.control._
 
 /**
@@ -49,16 +50,16 @@ class ComboBoxControls(target: ComboBox[String]) extends PropertiesNodes[ComboBo
   val txfVisibleRowCount = new TextField {
     text = target.visibleRowCount.get.toString
   }
-  txfVisibleRowCount.onAction = { actionEvent => fillIntPropertyFromText(target.visibleRowCount, txfVisibleRowCount, false) }
+  txfVisibleRowCount.onAction = { actionEvent: ActionEvent => fillIntPropertyFromText(target.visibleRowCount, txfVisibleRowCount, false) }
 
   val btnAddItem = new Button {
     text = "Add new Item"
-    onAction = { actionEvent => addNewTab() }
+    onAction = { actionEvent: ActionEvent => addNewTab() }
   }
 
   val btnRemoveItem = new Button {
     text = "Remove Item"
-    onAction = { actionEvent => removeCurrentItem() }
+    onAction = { actionEvent: ActionEvent => removeCurrentItem() }
   }
 
   super.addNode("Visible Rows", txfVisibleRowCount)

--- a/scalafx-demos/src/main/scala/scalafx/controls/controls/ProgressIndicatorControls.scala
+++ b/scalafx-demos/src/main/scala/scalafx/controls/controls/ProgressIndicatorControls.scala
@@ -27,13 +27,14 @@
 package scalafx.controls.controls
 
 import scalafx.Includes._
+import scalafx.event.ActionEvent
 import scalafx.scene.control.{Label, ProgressIndicator, TextField}
 
 class ProgressIndicatorControls(target: ProgressIndicator)
   extends PropertiesNodes[ProgressIndicator](target, target.getClass.getSimpleName + " Properties") {
 
   val txfValue = new TextField
-  txfValue.onAction = { actionEvent =>
+  txfValue.onAction = { actionEvent: ActionEvent =>
     fillDoublePropertyFromText(
       target.progress, txfValue, true, () => (target.progress = ProgressIndicator.INDETERMINATE_PROGRESS))
   }

--- a/scalafx-demos/src/main/scala/scalafx/controls/controls/ProgressIndicatorControls.scala
+++ b/scalafx-demos/src/main/scala/scalafx/controls/controls/ProgressIndicatorControls.scala
@@ -33,7 +33,7 @@ class ProgressIndicatorControls(target: ProgressIndicator)
   extends PropertiesNodes[ProgressIndicator](target, target.getClass.getSimpleName + " Properties") {
 
   val txfValue = new TextField
-  txfValue.onAction = handle {
+  txfValue.onAction = { actionEvent =>
     fillDoublePropertyFromText(
       target.progress, txfValue, true, () => (target.progress = ProgressIndicator.INDETERMINATE_PROGRESS))
   }

--- a/scalafx-demos/src/main/scala/scalafx/controls/controls/PropertiesNodes.scala
+++ b/scalafx-demos/src/main/scala/scalafx/controls/controls/PropertiesNodes.scala
@@ -52,7 +52,7 @@ abstract class PropertiesNodes[T](target: T, title: String) extends TitledPane {
 
   protected val btnReset = new Button {
     text = "Reset"
-    onAction = handle {resetProperties()}
+    onAction = { actionEvent => resetProperties() }
     alignmentInParent = Pos.Center
   }
 

--- a/scalafx-demos/src/main/scala/scalafx/controls/controls/PropertiesNodes.scala
+++ b/scalafx-demos/src/main/scala/scalafx/controls/controls/PropertiesNodes.scala
@@ -29,6 +29,7 @@ package scalafx.controls.controls
 
 import scalafx.Includes._
 import scalafx.beans.property._
+import scalafx.event.ActionEvent
 import scalafx.geometry.Pos
 import scalafx.scene.Node
 import scalafx.scene.control._
@@ -52,7 +53,7 @@ abstract class PropertiesNodes[T](target: T, title: String) extends TitledPane {
 
   protected val btnReset = new Button {
     text = "Reset"
-    onAction = { actionEvent => resetProperties() }
+    onAction = { actionEvent: ActionEvent => resetProperties() }
     alignmentInParent = Pos.Center
   }
 

--- a/scalafx-demos/src/main/scala/scalafx/controls/tableview/BarChartWithTableViewDemo.scala
+++ b/scalafx-demos/src/main/scala/scalafx/controls/tableview/BarChartWithTableViewDemo.scala
@@ -85,7 +85,7 @@ object BarChartWithTableViewDemo extends JFXApp {
       title = chartTitle
       data = XYChart.Series(chartData.map(d => XYChart.Data[String, Number](d.name(), d.value())))
       legendVisible = false
-      onMouseClicked = handle {showAsTable(title(), chartData)}
+      onMouseClicked = { mouseEvent => showAsTable(title(), chartData) }
     }
 
 

--- a/scalafx-demos/src/main/scala/scalafx/controls/tableview/BarChartWithTableViewDemo.scala
+++ b/scalafx-demos/src/main/scala/scalafx/controls/tableview/BarChartWithTableViewDemo.scala
@@ -37,6 +37,7 @@ import scalafx.scene.Scene
 import scalafx.scene.chart.{BarChart, CategoryAxis, NumberAxis, XYChart}
 import scalafx.scene.control.TableColumn._
 import scalafx.scene.control.{Label, TableColumn, TableView}
+import scalafx.scene.input.MouseEvent
 import scalafx.scene.layout.{BorderPane, HBox}
 import scalafx.stage.{Modality, Stage}
 
@@ -85,7 +86,7 @@ object BarChartWithTableViewDemo extends JFXApp {
       title = chartTitle
       data = XYChart.Series(chartData.map(d => XYChart.Data[String, Number](d.name(), d.value())))
       legendVisible = false
-      onMouseClicked = { mouseEvent => showAsTable(title(), chartData) }
+      onMouseClicked = { mouseEvent: MouseEvent => showAsTable(title(), chartData) }
     }
 
 

--- a/scalafx/src/main/scala/scalafx/animation/Animation.scala
+++ b/scalafx/src/main/scala/scalafx/animation/Animation.scala
@@ -32,6 +32,7 @@ import scala.language.implicitConversions
 import scalafx.Includes._
 import scalafx.beans.property.{BooleanProperty, DoubleProperty, IntegerProperty, ObjectProperty, ReadOnlyDoubleProperty, ReadOnlyObjectProperty}
 import scalafx.delegate._
+import scalafx.event.ActionEvent
 import scalafx.util.Duration
 import scalafx.util.Duration.sfxDuration2jfx
 
@@ -167,7 +168,7 @@ abstract class Animation protected(override val delegate: jfxa.Animation)
   def onFinished_=(handler: jfxe.EventHandler[jfxe.ActionEvent]) {
     onFinished() = handler
   }
-  def onFinished_=(handler: jfxe.ActionEvent => Unit) {
+  def onFinished_=(handler: ActionEvent => Unit) {
     onFinished() = new jfxe.EventHandler[jfxe.ActionEvent] {
       override def handle(event: jfxe.ActionEvent): Unit = handler(event)
     }

--- a/scalafx/src/main/scala/scalafx/animation/Animation.scala
+++ b/scalafx/src/main/scala/scalafx/animation/Animation.scala
@@ -167,6 +167,11 @@ abstract class Animation protected(override val delegate: jfxa.Animation)
   def onFinished_=(handler: jfxe.EventHandler[jfxe.ActionEvent]) {
     onFinished() = handler
   }
+  def onFinished_=(handler: jfxe.ActionEvent => Unit) {
+    onFinished() = new jfxe.EventHandler[jfxe.ActionEvent] {
+      override def handle(event: jfxe.ActionEvent): Unit = handler(event)
+    }
+  }
 
   /**
    * Defines the direction/speed at which the $AN is expected to be played. $DV 1.0

--- a/scalafx/src/main/scala/scalafx/concurrent/Service.scala
+++ b/scalafx/src/main/scala/scalafx/concurrent/Service.scala
@@ -78,7 +78,7 @@ abstract class Service[T](override val delegate: jfxc.Service[T])
   def onCancelled_=(v: jfxe.EventHandler[jfxc.WorkerStateEvent]) {
     onCancelled() = v
   }
-  def onCancelled_=(handler: jfxc.WorkerStateEvent => Unit) {
+  def onCancelled_=(handler: WorkerStateEvent => Unit) {
     onCancelled() = new jfxe.EventHandler[jfxc.WorkerStateEvent] {
       override def handle(event: jfxc.WorkerStateEvent): Unit = handler(event)
     }
@@ -91,7 +91,7 @@ abstract class Service[T](override val delegate: jfxc.Service[T])
   def onFailed_=(v: jfxe.EventHandler[jfxc.WorkerStateEvent]) {
     onFailed() = v
   }
-  def onFailed_=(handler: jfxc.WorkerStateEvent => Unit) {
+  def onFailed_=(handler: WorkerStateEvent => Unit) {
     onFailed() = new jfxe.EventHandler[jfxc.WorkerStateEvent] {
       override def handle(event: jfxc.WorkerStateEvent): Unit = handler(event)
     }
@@ -104,7 +104,7 @@ abstract class Service[T](override val delegate: jfxc.Service[T])
   def onReady_=(v: jfxe.EventHandler[jfxc.WorkerStateEvent]) {
     onReady() = v
   }
-  def onReady_=(handler: jfxc.WorkerStateEvent => Unit) {
+  def onReady_=(handler: WorkerStateEvent => Unit) {
     onReady() = new jfxe.EventHandler[jfxc.WorkerStateEvent] {
       override def handle(event: jfxc.WorkerStateEvent): Unit = handler(event)
     }
@@ -117,7 +117,7 @@ abstract class Service[T](override val delegate: jfxc.Service[T])
   def onRunning_=(v: jfxe.EventHandler[jfxc.WorkerStateEvent]) {
     onRunning() = v
   }
-  def onRunning_=(handler: jfxc.WorkerStateEvent => Unit) {
+  def onRunning_=(handler: WorkerStateEvent => Unit) {
     onRunning() = new jfxe.EventHandler[jfxc.WorkerStateEvent] {
       override def handle(event: jfxc.WorkerStateEvent): Unit = handler(event)
     }
@@ -131,7 +131,7 @@ abstract class Service[T](override val delegate: jfxc.Service[T])
   def onScheduled_=(v: jfxe.EventHandler[jfxc.WorkerStateEvent]) {
     onScheduled() = v
   }
-  def onScheduled_=(handler: jfxc.WorkerStateEvent => Unit) {
+  def onScheduled_=(handler: WorkerStateEvent => Unit) {
     onScheduled() = new jfxe.EventHandler[jfxc.WorkerStateEvent] {
       override def handle(event: jfxc.WorkerStateEvent): Unit = handler(event)
     }
@@ -145,7 +145,7 @@ abstract class Service[T](override val delegate: jfxc.Service[T])
   def onSucceeded_=(v: jfxe.EventHandler[jfxc.WorkerStateEvent]) {
     onSucceeded() = v
   }
-  def onSucceeded_=(handler: jfxc.WorkerStateEvent => Unit) {
+  def onSucceeded_=(handler: WorkerStateEvent => Unit) {
     onSucceeded() = new jfxe.EventHandler[jfxc.WorkerStateEvent] {
       override def handle(event: jfxc.WorkerStateEvent): Unit = handler(event)
     }

--- a/scalafx/src/main/scala/scalafx/concurrent/Service.scala
+++ b/scalafx/src/main/scala/scalafx/concurrent/Service.scala
@@ -78,6 +78,11 @@ abstract class Service[T](override val delegate: jfxc.Service[T])
   def onCancelled_=(v: jfxe.EventHandler[jfxc.WorkerStateEvent]) {
     onCancelled() = v
   }
+  def onCancelled_=(handler: jfxc.WorkerStateEvent => Unit) {
+    onCancelled() = new jfxe.EventHandler[jfxc.WorkerStateEvent] {
+      override def handle(event: jfxc.WorkerStateEvent): Unit = handler(event)
+    }
+  }
 
   /**
    * The onFailed event handler is called whenever the Task state transitions to the FAILED state.
@@ -85,6 +90,11 @@ abstract class Service[T](override val delegate: jfxc.Service[T])
   def onFailed = delegate.onFailedProperty
   def onFailed_=(v: jfxe.EventHandler[jfxc.WorkerStateEvent]) {
     onFailed() = v
+  }
+  def onFailed_=(handler: jfxc.WorkerStateEvent => Unit) {
+    onFailed() = new jfxe.EventHandler[jfxc.WorkerStateEvent] {
+      override def handle(event: jfxc.WorkerStateEvent): Unit = handler(event)
+    }
   }
 
   /**
@@ -94,6 +104,11 @@ abstract class Service[T](override val delegate: jfxc.Service[T])
   def onReady_=(v: jfxe.EventHandler[jfxc.WorkerStateEvent]) {
     onReady() = v
   }
+  def onReady_=(handler: jfxc.WorkerStateEvent => Unit) {
+    onReady() = new jfxe.EventHandler[jfxc.WorkerStateEvent] {
+      override def handle(event: jfxc.WorkerStateEvent): Unit = handler(event)
+    }
+  }
 
   /**
    * The onRunning event handler is called whenever the Task state transitions to the RUNNING state.
@@ -101,6 +116,11 @@ abstract class Service[T](override val delegate: jfxc.Service[T])
   def onRunning = delegate.onRunningProperty
   def onRunning_=(v: jfxe.EventHandler[jfxc.WorkerStateEvent]) {
     onRunning() = v
+  }
+  def onRunning_=(handler: jfxc.WorkerStateEvent => Unit) {
+    onRunning() = new jfxe.EventHandler[jfxc.WorkerStateEvent] {
+      override def handle(event: jfxc.WorkerStateEvent): Unit = handler(event)
+    }
   }
 
   /**
@@ -111,6 +131,11 @@ abstract class Service[T](override val delegate: jfxc.Service[T])
   def onScheduled_=(v: jfxe.EventHandler[jfxc.WorkerStateEvent]) {
     onScheduled() = v
   }
+  def onScheduled_=(handler: jfxc.WorkerStateEvent => Unit) {
+    onScheduled() = new jfxe.EventHandler[jfxc.WorkerStateEvent] {
+      override def handle(event: jfxc.WorkerStateEvent): Unit = handler(event)
+    }
+  }
 
   /**
    * The onSucceeded event handler is called whenever the Task state transitions to the SUCCEEDED
@@ -119,6 +144,11 @@ abstract class Service[T](override val delegate: jfxc.Service[T])
   def onSucceeded = delegate.onSucceededProperty
   def onSucceeded_=(v: jfxe.EventHandler[jfxc.WorkerStateEvent]) {
     onSucceeded() = v
+  }
+  def onSucceeded_=(handler: jfxc.WorkerStateEvent => Unit) {
+    onSucceeded() = new jfxe.EventHandler[jfxc.WorkerStateEvent] {
+      override def handle(event: jfxc.WorkerStateEvent): Unit = handler(event)
+    }
   }
 
   /**

--- a/scalafx/src/main/scala/scalafx/concurrent/Task.scala
+++ b/scalafx/src/main/scala/scalafx/concurrent/Task.scala
@@ -64,7 +64,7 @@ abstract class Task[T](override val delegate: jfxc.Task[T])
   def onCancelled_=(v: jfxe.EventHandler[jfxc.WorkerStateEvent]) {
     onCancelled() = v
   }
-  def onCancelled_=(handler: jfxc.WorkerStateEvent => Unit) {
+  def onCancelled_=(handler: WorkerStateEvent => Unit) {
     onCancelled() = new jfxe.EventHandler[jfxc.WorkerStateEvent] {
       override def handle(event: jfxc.WorkerStateEvent): Unit = handler(event)
     }
@@ -77,7 +77,7 @@ abstract class Task[T](override val delegate: jfxc.Task[T])
   def onFailed_=(v: jfxe.EventHandler[jfxc.WorkerStateEvent]) {
     onFailed() = v
   }
-  def onFailed_=(handler: jfxc.WorkerStateEvent => Unit) {
+  def onFailed_=(handler: WorkerStateEvent => Unit) {
     onFailed() = new jfxe.EventHandler[jfxc.WorkerStateEvent] {
       override def handle(event: jfxc.WorkerStateEvent): Unit = handler(event)
     }
@@ -90,7 +90,7 @@ abstract class Task[T](override val delegate: jfxc.Task[T])
   def onRunning_=(v: jfxe.EventHandler[jfxc.WorkerStateEvent]) {
     onRunning() = v
   }
-  def onRunning_=(handler: jfxc.WorkerStateEvent => Unit) {
+  def onRunning_=(handler: WorkerStateEvent => Unit) {
     onRunning() = new jfxe.EventHandler[jfxc.WorkerStateEvent] {
       override def handle(event: jfxc.WorkerStateEvent): Unit = handler(event)
     }
@@ -104,7 +104,7 @@ abstract class Task[T](override val delegate: jfxc.Task[T])
   def onScheduled_=(v: jfxe.EventHandler[jfxc.WorkerStateEvent]) {
     onScheduled() = v
   }
-  def onScheduled_=(handler: jfxc.WorkerStateEvent => Unit) {
+  def onScheduled_=(handler: WorkerStateEvent => Unit) {
     onScheduled() = new jfxe.EventHandler[jfxc.WorkerStateEvent] {
       override def handle(event: jfxc.WorkerStateEvent): Unit = handler(event)
     }
@@ -118,7 +118,7 @@ abstract class Task[T](override val delegate: jfxc.Task[T])
   def onSucceeded_=(v: jfxe.EventHandler[jfxc.WorkerStateEvent]) {
     onSucceeded() = v
   }
-  def onSucceeded_=(handler: jfxc.WorkerStateEvent => Unit) {
+  def onSucceeded_=(handler: WorkerStateEvent => Unit) {
     onSucceeded() = new jfxe.EventHandler[jfxc.WorkerStateEvent] {
       override def handle(event: jfxc.WorkerStateEvent): Unit = handler(event)
     }

--- a/scalafx/src/main/scala/scalafx/concurrent/Task.scala
+++ b/scalafx/src/main/scala/scalafx/concurrent/Task.scala
@@ -64,6 +64,11 @@ abstract class Task[T](override val delegate: jfxc.Task[T])
   def onCancelled_=(v: jfxe.EventHandler[jfxc.WorkerStateEvent]) {
     onCancelled() = v
   }
+  def onCancelled_=(handler: jfxc.WorkerStateEvent => Unit) {
+    onCancelled() = new jfxe.EventHandler[jfxc.WorkerStateEvent] {
+      override def handle(event: jfxc.WorkerStateEvent): Unit = handler(event)
+    }
+  }
 
   /**
    * The onFailed event handler is called whenever the Task state transitions to the FAILED state.
@@ -72,6 +77,11 @@ abstract class Task[T](override val delegate: jfxc.Task[T])
   def onFailed_=(v: jfxe.EventHandler[jfxc.WorkerStateEvent]) {
     onFailed() = v
   }
+  def onFailed_=(handler: jfxc.WorkerStateEvent => Unit) {
+    onFailed() = new jfxe.EventHandler[jfxc.WorkerStateEvent] {
+      override def handle(event: jfxc.WorkerStateEvent): Unit = handler(event)
+    }
+  }
 
   /**
    * The onRunning event handler is called whenever the Task state transitions to the RUNNING state.
@@ -79,6 +89,11 @@ abstract class Task[T](override val delegate: jfxc.Task[T])
   def onRunning = delegate.onRunningProperty
   def onRunning_=(v: jfxe.EventHandler[jfxc.WorkerStateEvent]) {
     onRunning() = v
+  }
+  def onRunning_=(handler: jfxc.WorkerStateEvent => Unit) {
+    onRunning() = new jfxe.EventHandler[jfxc.WorkerStateEvent] {
+      override def handle(event: jfxc.WorkerStateEvent): Unit = handler(event)
+    }
   }
 
   /**
@@ -89,6 +104,11 @@ abstract class Task[T](override val delegate: jfxc.Task[T])
   def onScheduled_=(v: jfxe.EventHandler[jfxc.WorkerStateEvent]) {
     onScheduled() = v
   }
+  def onScheduled_=(handler: jfxc.WorkerStateEvent => Unit) {
+    onScheduled() = new jfxe.EventHandler[jfxc.WorkerStateEvent] {
+      override def handle(event: jfxc.WorkerStateEvent): Unit = handler(event)
+    }
+  }
 
   /**
    * The onSucceeded event handler is called whenever the Task state transitions to the SUCCEEDED
@@ -97,5 +117,10 @@ abstract class Task[T](override val delegate: jfxc.Task[T])
   def onSucceeded = delegate.onSucceededProperty
   def onSucceeded_=(v: jfxe.EventHandler[jfxc.WorkerStateEvent]) {
     onSucceeded() = v
+  }
+  def onSucceeded_=(handler: jfxc.WorkerStateEvent => Unit) {
+    onSucceeded() = new jfxe.EventHandler[jfxc.WorkerStateEvent] {
+      override def handle(event: jfxc.WorkerStateEvent): Unit = handler(event)
+    }
   }
 }

--- a/scalafx/src/main/scala/scalafx/event/EventIncludes.scala
+++ b/scalafx/src/main/scala/scalafx/event/EventIncludes.scala
@@ -136,26 +136,4 @@ trait EventIncludes {
       }
     }
 
-  /**
-   * Converts a closure to a JavaFX EventHandler. It is used when the event properties ''will be used''.
-   *
-   * Enables following use:
-   * <pre>
-      button.onAction = (e:ActionEvent) => {
-        println("Handling button action: " + e)
-        doSomething(e)
-      }
-   * </pre>
-   *
-   * @tparam J JavaFX Event subclass.
-   * @param handler Closure that that takes scalafx.event.Event as argument.
-   * @return JavaFX EventHandler which handle method will call handler
-   */
-  implicit def eventClosureWrapperWithParam[J <: jfxe.Event, S <: SFXDelegate[J], R](handler: (S) => R)(implicit jfx2sfx: J => S): jfxe.EventHandler[J] =
-    new jfxe.EventHandler[J] {
-      def handle(event: J) {
-        handler(event)
-      }
-    }
-
 }

--- a/scalafx/src/main/scala/scalafx/event/EventIncludes.scala
+++ b/scalafx/src/main/scala/scalafx/event/EventIncludes.scala
@@ -136,4 +136,26 @@ trait EventIncludes {
       }
     }
 
+  /**
+   * Converts a closure to a JavaFX EventHandler. It is used when the event properties ''will be used''.
+   *
+   * Enables following use:
+   * <pre>
+      button.onAction = (e:ActionEvent) => {
+        println("Handling button action: " + e)
+        doSomething(e)
+      }
+   * </pre>
+   *
+   * @tparam J JavaFX Event subclass.
+   * @param handler Closure that that takes scalafx.event.Event as argument.
+   * @return JavaFX EventHandler which handle method will call handler
+   */
+  implicit def eventClosureWrapperWithParam[J <: jfxe.Event, S <: SFXDelegate[J], R](handler: (S) => R)(implicit jfx2sfx: J => S): jfxe.EventHandler[J] =
+    new jfxe.EventHandler[J] {
+      def handle(event: J) {
+        handler(event)
+      }
+    }
+
 }

--- a/scalafx/src/main/scala/scalafx/scene/Node.scala
+++ b/scalafx/src/main/scala/scalafx/scene/Node.scala
@@ -335,6 +335,12 @@ abstract class Node protected(override val delegate: jfxs.Node)
     onContextMenuRequested() = v
   }
 
+  def onContextMenuRequested_=[T >: jfxsi.ContextMenuEvent <: jfxe.Event](handler: T => Unit) {
+    onContextMenuRequested() = new jfxe.EventHandler[T] {
+      override def handle(event: T): Unit = handler(event)
+    }
+  }
+
   /**
    * Defines a function to be called when drag gesture has been detected.
    */
@@ -342,6 +348,12 @@ abstract class Node protected(override val delegate: jfxs.Node)
 
   def onDragDetected_=(v: jfxe.EventHandler[_ >: jfxsi.MouseEvent]) {
     onDragDetected() = v
+  }
+
+  def onDragDetected_=[T >: jfxsi.MouseEvent <: jfxe.Event](handler: T => Unit) {
+    onDragDetected() = new jfxe.EventHandler[T] {
+      override def handle(event: T): Unit = handler(event)
+    }
   }
 
   /**
@@ -354,6 +366,12 @@ abstract class Node protected(override val delegate: jfxs.Node)
     onDragDone() = v
   }
 
+  def onDragDone_=[T >: jfxsi.DragEvent <: jfxe.Event](handler: T => Unit) {
+    onDragDone() = new jfxe.EventHandler[T] {
+      override def handle(event: T): Unit = handler(event)
+    }
+  }
+
   /**
    * Defines a function to be called when the mouse button is released on this Node during drag
    * and drop gesture.
@@ -362,6 +380,12 @@ abstract class Node protected(override val delegate: jfxs.Node)
 
   def onDragDropped_=(v: jfxe.EventHandler[_ >: jfxsi.DragEvent]) {
     onDragDropped() = v
+  }
+
+  def onDragDropped_=[T >: jfxsi.DragEvent <: jfxe.Event](handler: T => Unit) {
+    onDragDropped() = new jfxe.EventHandler[T] {
+      override def handle(event: T): Unit = handler(event)
+    }
   }
 
   /**
@@ -373,6 +397,12 @@ abstract class Node protected(override val delegate: jfxs.Node)
     onDragEntered() = v
   }
 
+  def onDragEntered_=[T >: jfxsi.DragEvent <: jfxe.Event](handler: T => Unit) {
+    onDragEntered() = new jfxe.EventHandler[T] {
+      override def handle(event: T): Unit = handler(event)
+    }
+  }
+
   /**
    * Defines a function to be called when drag gesture exits this Node.
    */
@@ -382,6 +412,12 @@ abstract class Node protected(override val delegate: jfxs.Node)
     onDragExited() = v
   }
 
+  def onDragExited_=[T >: jfxsi.DragEvent <: jfxe.Event](handler: T => Unit) {
+    onDragExited() = new jfxe.EventHandler[T] {
+      override def handle(event: T): Unit = handler(event)
+    }
+  }
+
   /**
    * Defines a function to be called when drag gesture progresses within this Node.
    */
@@ -389,6 +425,12 @@ abstract class Node protected(override val delegate: jfxs.Node)
 
   def onDragOver_=(v: jfxe.EventHandler[_ >: jfxsi.DragEvent]) {
     onDragOver() = v
+  }
+
+  def onDragOver_=[T >: jfxsi.DragEvent <: jfxe.Event](handler: T => Unit) {
+    onDragOver() = new jfxe.EventHandler[T] {
+      override def handle(event: T): Unit = handler(event)
+    }
   }
 
   /**
@@ -401,6 +443,12 @@ abstract class Node protected(override val delegate: jfxs.Node)
     onInputMethodTextChanged() = v
   }
 
+  def onInputMethodTextChanged_=[T >: jfxsi.InputMethodEvent <: jfxe.Event](handler: T => Unit) {
+    onInputMethodTextChanged() = new jfxe.EventHandler[T] {
+      override def handle(event: T): Unit = handler(event)
+    }
+  }
+
   /**
    * Defines a function to be called when this Node or its child Node has input focus and a key
    * has been pressed.
@@ -409,6 +457,12 @@ abstract class Node protected(override val delegate: jfxs.Node)
 
   def onKeyPressed_=(v: jfxe.EventHandler[_ >: jfxsi.KeyEvent]) {
     onKeyPressed() = v
+  }
+
+  def onKeyPressed_=[T >: jfxsi.KeyEvent <: jfxe.Event](handler: T => Unit) {
+    onKeyPressed() = new jfxe.EventHandler[T] {
+      override def handle(event: T): Unit = handler(event)
+    }
   }
 
   /**
@@ -421,6 +475,12 @@ abstract class Node protected(override val delegate: jfxs.Node)
     onKeyReleased() = v
   }
 
+  def onKeyReleased_=[T >: jfxsi.KeyEvent <: jfxe.Event](handler: T => Unit) {
+    onKeyReleased() = new jfxe.EventHandler[T] {
+      override def handle(event: T): Unit = handler(event)
+    }
+  }
+
   /**
    * Defines a function to be called when this Node or its child Node has input focus and a key
    * has been typed.
@@ -429,6 +489,12 @@ abstract class Node protected(override val delegate: jfxs.Node)
 
   def onKeyTyped_=(v: jfxe.EventHandler[_ >: jfxsi.KeyEvent]) {
     onKeyTyped() = v
+  }
+
+  def onKeyTyped_=[T >: jfxsi.KeyEvent <: jfxe.Event](handler: T => Unit) {
+    onKeyTyped() = new jfxe.EventHandler[T] {
+      override def handle(event: T): Unit = handler(event)
+    }
   }
 
   /**
@@ -441,6 +507,12 @@ abstract class Node protected(override val delegate: jfxs.Node)
     onMouseClicked() = v
   }
 
+  def onMouseClicked_=[T >: jfxsi.MouseEvent <: jfxe.Event](handler: T => Unit) {
+    onMouseClicked() = new jfxe.EventHandler[T] {
+      override def handle(event: T): Unit = handler(event)
+    }
+  }
+
   /**
    * Defines a function to be called when a mouse button is pressed on this Node and then dragged.
    */
@@ -448,6 +520,12 @@ abstract class Node protected(override val delegate: jfxs.Node)
 
   def onMouseDragged_=(v: jfxe.EventHandler[_ >: jfxsi.MouseEvent]) {
     onMouseDragged() = v
+  }
+
+  def onMouseDragged_=[T >: jfxsi.MouseEvent <: jfxe.Event](handler: T => Unit) {
+    onMouseDragged() = new jfxe.EventHandler[T] {
+      override def handle(event: T): Unit = handler(event)
+    }
   }
 
   /**
@@ -459,6 +537,12 @@ abstract class Node protected(override val delegate: jfxs.Node)
     onMouseDragEntered() = v
   }
 
+  def onMouseDragEntered_=[T >: jfxsi.MouseDragEvent <: jfxe.Event](handler: T => Unit) {
+    onMouseDragEntered() = new jfxe.EventHandler[T] {
+      override def handle(event: T): Unit = handler(event)
+    }
+  }
+
   /**
    * Defines a function to be called when a full press-drag-release gesture leaves this Node.
    */
@@ -468,6 +552,12 @@ abstract class Node protected(override val delegate: jfxs.Node)
     onMouseDragExited() = v
   }
 
+  def onMouseDragExited_=[T >: jfxsi.MouseDragEvent <: jfxe.Event](handler: T => Unit) {
+    onMouseDragExited() = new jfxe.EventHandler[T] {
+      override def handle(event: T): Unit = handler(event)
+    }
+  }
+
   /**
    * Defines a function to be called when a full press-drag-release gesture progresses within this Node.
    */
@@ -475,6 +565,12 @@ abstract class Node protected(override val delegate: jfxs.Node)
 
   def onMouseDragOver_=(v: jfxe.EventHandler[_ >: jfxsi.MouseDragEvent]) {
     onMouseDragOver() = v
+  }
+
+  def onMouseDragOver_=[T >: jfxsi.MouseDragEvent <: jfxe.Event](handler: T => Unit) {
+    onMouseDragOver() = new jfxe.EventHandler[T] {
+      override def handle(event: T): Unit = handler(event)
+    }
   }
 
   /**
@@ -487,6 +583,12 @@ abstract class Node protected(override val delegate: jfxs.Node)
     onMouseDragReleased() = v
   }
 
+  def onMouseDragReleased_=[T >: jfxsi.MouseDragEvent <: jfxe.Event](handler: T => Unit) {
+    onMouseDragReleased() = new jfxe.EventHandler[T] {
+      override def handle(event: T): Unit = handler(event)
+    }
+  }
+
   /**
    * Defines a function to be called when the mouse enters this Node.
    */
@@ -494,6 +596,12 @@ abstract class Node protected(override val delegate: jfxs.Node)
 
   def onMouseEntered_=(v: jfxe.EventHandler[_ >: jfxsi.MouseEvent]) {
     onMouseEntered() = v
+  }
+
+  def onMouseEntered_=[T >: jfxsi.MouseEvent <: jfxe.Event](handler: T => Unit) {
+    onMouseEntered() = new jfxe.EventHandler[T] {
+      override def handle(event: T): Unit = handler(event)
+    }
   }
 
   /**
@@ -505,10 +613,22 @@ abstract class Node protected(override val delegate: jfxs.Node)
     onMouseExited() = v
   }
 
+  def onMouseExited_=[T >: jfxsi.MouseEvent <: jfxe.Event](handler: T => Unit) {
+    onMouseExited() = new jfxe.EventHandler[T] {
+      override def handle(event: T): Unit = handler(event)
+    }
+  }
+
   def onMouseMoved = delegate.onMouseMovedProperty
 
   def onMouseMoved_=(v: jfxe.EventHandler[_ >: jfxsi.MouseEvent]) {
     onMouseMoved() = v
+  }
+
+  def onMouseMoved_=[T >: jfxsi.MouseEvent <: jfxe.Event](handler: T => Unit) {
+    onMouseMoved() = new jfxe.EventHandler[T] {
+      override def handle(event: T): Unit = handler(event)
+    }
   }
 
   /**
@@ -520,6 +640,12 @@ abstract class Node protected(override val delegate: jfxs.Node)
     onMousePressed() = v
   }
 
+  def onMousePressed_=[T >: jfxsi.MouseEvent <: jfxe.Event](handler: T => Unit) {
+    onMousePressed() = new jfxe.EventHandler[T] {
+      override def handle(event: T): Unit = handler(event)
+    }
+  }
+
   /**
    * Defines a function to be called when a mouse button has been released on this Node.
    */
@@ -529,6 +655,12 @@ abstract class Node protected(override val delegate: jfxs.Node)
     onMouseReleased() = v
   }
 
+  def onMouseReleased_=[T >: jfxsi.MouseEvent <: jfxe.Event](handler: T => Unit) {
+    onMouseReleased() = new jfxe.EventHandler[T] {
+      override def handle(event: T): Unit = handler(event)
+    }
+  }
+
   /**
    * Defines a function to be called when user performs a scrolling action.
    */
@@ -536,6 +668,12 @@ abstract class Node protected(override val delegate: jfxs.Node)
 
   def onScroll_=(v: jfxe.EventHandler[_ >: jfxsi.ScrollEvent]) {
     onScroll() = v
+  }
+
+  def onScroll_=[T >: jfxsi.ScrollEvent <: jfxe.Event](handler: T => Unit) {
+    onScroll() = new jfxe.EventHandler[T] {
+      override def handle(event: T): Unit = handler(event)
+    }
   }
 
   /**
@@ -1056,6 +1194,11 @@ abstract class Node protected(override val delegate: jfxs.Node)
   def onRotate_=(v: jfxe.EventHandler[jfxsi.RotateEvent]) {
     onRotate() = v
   }
+  def onRotate_=(handler: jfxsi.RotateEvent => Unit) {
+    onRotate() = new jfxe.EventHandler[jfxsi.RotateEvent] {
+      override def handle(event: jfxsi.RotateEvent): Unit = handler(event)
+    }
+  }
 
   /**
    * Defines a function to be called when a rotation gesture ends.
@@ -1065,6 +1208,11 @@ abstract class Node protected(override val delegate: jfxs.Node)
   def onRotationFinished = delegate.onRotationFinishedProperty()
   def onRotationFinished_=(v: jfxe.EventHandler[jfxsi.RotateEvent]) {
     onRotationFinished() = v
+  }
+  def onRotationFinished_=(handler: jfxsi.RotateEvent => Unit) {
+    onRotationFinished() = new jfxe.EventHandler[jfxsi.RotateEvent] {
+      override def handle(event: jfxsi.RotateEvent): Unit = handler(event)
+    }
   }
 
   /**
@@ -1076,6 +1224,11 @@ abstract class Node protected(override val delegate: jfxs.Node)
   def onRotationStarted_=(v: jfxe.EventHandler[jfxsi.RotateEvent]) {
     onRotationStarted() = v
   }
+  def onRotationStarted_=(handler: jfxsi.RotateEvent => Unit) {
+    onRotationStarted() = new jfxe.EventHandler[jfxsi.RotateEvent] {
+      override def handle(event: jfxsi.RotateEvent): Unit = handler(event)
+    }
+  }
 
   /**
    * Defines a function to be called when a Scroll gesture ends.
@@ -1085,6 +1238,11 @@ abstract class Node protected(override val delegate: jfxs.Node)
   def onScrollFinished = delegate.onScrollFinishedProperty()
   def onScrollFinished_=(v: jfxe.EventHandler[jfxsi.ScrollEvent]) {
     onScrollFinished() = v
+  }
+  def onScrollFinished_=(handler: jfxsi.ScrollEvent => Unit) {
+    onScrollFinished() = new jfxe.EventHandler[jfxsi.ScrollEvent] {
+      override def handle(event: jfxsi.ScrollEvent): Unit = handler(event)
+    }
   }
 
   /**
@@ -1096,6 +1254,11 @@ abstract class Node protected(override val delegate: jfxs.Node)
   def onScrollStarted_=(v: jfxe.EventHandler[jfxsi.ScrollEvent]) {
     onScrollStarted() = v
   }
+  def onScrollStarted_=(handler: jfxsi.ScrollEvent => Unit) {
+    onScrollStarted() = new jfxe.EventHandler[jfxsi.ScrollEvent] {
+      override def handle(event: jfxsi.ScrollEvent): Unit = handler(event)
+    }
+  }
 
   /**
    * Defines a function to be called when a Swipe Down gesture starts.
@@ -1105,6 +1268,11 @@ abstract class Node protected(override val delegate: jfxs.Node)
   def onSwipeDown = delegate.onSwipeDownProperty()
   def onSwipeDown_=(v: jfxe.EventHandler[jfxsi.SwipeEvent]) {
     onSwipeDown() = v
+  }
+  def onSwipeDown_=(handler: jfxsi.SwipeEvent => Unit) {
+    onSwipeDown() = new jfxe.EventHandler[jfxsi.SwipeEvent] {
+      override def handle(event: jfxsi.SwipeEvent): Unit = handler(event)
+    }
   }
 
   /**
@@ -1116,6 +1284,11 @@ abstract class Node protected(override val delegate: jfxs.Node)
   def onSwipeLeft_=(v: jfxe.EventHandler[jfxsi.SwipeEvent]) {
     onSwipeLeft() = v
   }
+  def onSwipeLeft_=(handler: jfxsi.SwipeEvent => Unit) {
+    onSwipeLeft() = new jfxe.EventHandler[jfxsi.SwipeEvent] {
+      override def handle(event: jfxsi.SwipeEvent): Unit = handler(event)
+    }
+  }
 
   /**
    * Defines a function to be called when a Swipe Up gesture starts.
@@ -1125,6 +1298,11 @@ abstract class Node protected(override val delegate: jfxs.Node)
   def onSwipeUp = delegate.onSwipeUpProperty()
   def onSwipeUp_=(v: jfxe.EventHandler[jfxsi.SwipeEvent]) {
     onSwipeUp() = v
+  }
+  def onSwipeUp_=(handler: jfxsi.SwipeEvent => Unit) {
+    onSwipeUp() = new jfxe.EventHandler[jfxsi.SwipeEvent] {
+      override def handle(event: jfxsi.SwipeEvent): Unit = handler(event)
+    }
   }
 
   /**
@@ -1136,6 +1314,11 @@ abstract class Node protected(override val delegate: jfxs.Node)
   def onSwipeRight_=(v: jfxe.EventHandler[jfxsi.SwipeEvent]) {
     onSwipeRight() = v
   }
+  def onSwipeRight_=(handler: jfxsi.SwipeEvent => Unit) {
+    onSwipeRight() = new jfxe.EventHandler[jfxsi.SwipeEvent] {
+      override def handle(event: jfxsi.SwipeEvent): Unit = handler(event)
+    }
+  }
 
   /**
    * Defines a function to be called when user performs a Touch action.
@@ -1145,6 +1328,11 @@ abstract class Node protected(override val delegate: jfxs.Node)
   def onZoom = delegate.onZoomProperty()
   def onZoom_=(v: jfxe.EventHandler[jfxsi.ZoomEvent]) {
     onZoom() = v
+  }
+  def onZoom_=(handler: jfxsi.ZoomEvent => Unit) {
+    onZoom() = new jfxe.EventHandler[jfxsi.ZoomEvent] {
+      override def handle(event: jfxsi.ZoomEvent): Unit = handler(event)
+    }
   }
 
   /**
@@ -1156,6 +1344,11 @@ abstract class Node protected(override val delegate: jfxs.Node)
   def onZoomFinished_=(v: jfxe.EventHandler[jfxsi.ZoomEvent]) {
     onZoomFinished() = v
   }
+  def onZoomFinished_=(handler: jfxsi.ZoomEvent => Unit) {
+    onZoomFinished() = new jfxe.EventHandler[jfxsi.ZoomEvent] {
+      override def handle(event: jfxsi.ZoomEvent): Unit = handler(event)
+    }
+  }
 
   /**
    * Defines a function to be called when a Zoom gesture starts.
@@ -1165,6 +1358,11 @@ abstract class Node protected(override val delegate: jfxs.Node)
   def onZoomStarted = delegate.onZoomStartedProperty()
   def onZoomStarted_=(v: jfxe.EventHandler[jfxsi.ZoomEvent]) {
     onZoomStarted() = v
+  }
+  def onZoomStarted_=(handler: jfxsi.ZoomEvent => Unit) {
+    onZoomStarted() = new jfxe.EventHandler[jfxsi.ZoomEvent] {
+      override def handle(event: jfxsi.ZoomEvent): Unit = handler(event)
+    }
   }
 
   /**
@@ -1176,6 +1374,11 @@ abstract class Node protected(override val delegate: jfxs.Node)
   def onTouchMoved_=(v: jfxe.EventHandler[jfxsi.TouchEvent]) {
     onTouchMoved() = v
   }
+  def onTouchMoved_=(handler: jfxsi.TouchEvent => Unit) {
+    onTouchMoved() = new jfxe.EventHandler[jfxsi.TouchEvent] {
+      override def handle(event: jfxsi.TouchEvent): Unit = handler(event)
+    }
+  }
 
   /**
    * Defines a function to be called when user performs a Touch Pressed action.
@@ -1185,6 +1388,11 @@ abstract class Node protected(override val delegate: jfxs.Node)
   def onTouchPressed = delegate.onTouchPressedProperty()
   def onTouchPressed_=(v: jfxe.EventHandler[jfxsi.TouchEvent]) {
     onTouchPressed() = v
+  }
+  def onTouchPressed_=(handler: jfxsi.TouchEvent => Unit) {
+    onTouchPressed() = new jfxe.EventHandler[jfxsi.TouchEvent] {
+      override def handle(event: jfxsi.TouchEvent): Unit = handler(event)
+    }
   }
 
   /**
@@ -1196,6 +1404,11 @@ abstract class Node protected(override val delegate: jfxs.Node)
   def onTouchReleased_=(v: jfxe.EventHandler[jfxsi.TouchEvent]) {
     onTouchReleased() = v
   }
+  def onTouchReleased_=(handler: jfxsi.TouchEvent => Unit) {
+    onTouchReleased() = new jfxe.EventHandler[jfxsi.TouchEvent] {
+      override def handle(event: jfxsi.TouchEvent): Unit = handler(event)
+    }
+  }
 
   /**
    * Defines a function to be called when user performs a Touch Stationary action.
@@ -1205,6 +1418,11 @@ abstract class Node protected(override val delegate: jfxs.Node)
   def onTouchStationary = delegate.onTouchStationaryProperty()
   def onTouchStationary_=(v: jfxe.EventHandler[jfxsi.TouchEvent]) {
     onTouchStationary() = v
+  }
+  def onTouchStationary_=(handler: jfxsi.TouchEvent => Unit) {
+    onTouchStationary() = new jfxe.EventHandler[jfxsi.TouchEvent] {
+      override def handle(event: jfxsi.TouchEvent): Unit = handler(event)
+    }
   }
 
   override protected def eventHandlerDelegate = delegate.asInstanceOf[EventHandled]

--- a/scalafx/src/main/scala/scalafx/scene/Node.scala
+++ b/scalafx/src/main/scala/scalafx/scene/Node.scala
@@ -43,6 +43,7 @@ import scalafx.geometry.Point2D._
 import scalafx.geometry.{Bounds, Insets, Point2D, Point3D, Pos, _}
 import scalafx.scene.effect.{BlendMode, Effect}
 import scalafx.scene.image.WritableImage
+import scalafx.scene.input._
 import scalafx.scene.layout.Priority
 import scalafx.scene.transform.Transform
 
@@ -335,9 +336,10 @@ abstract class Node protected(override val delegate: jfxs.Node)
     onContextMenuRequested() = v
   }
 
-  def onContextMenuRequested_=[T >: jfxsi.ContextMenuEvent <: jfxe.Event](handler: T => Unit) {
-    onContextMenuRequested() = new jfxe.EventHandler[T] {
-      override def handle(event: T): Unit = handler(event)
+  def onContextMenuRequested_=[T >: ContextMenuEvent <: Event, U >: jfxsi.ContextMenuEvent <: jfxe.Event](handler: T => Unit)
+                                                                                                         (implicit jfx2sfx: U => T) {
+    onContextMenuRequested() = new jfxe.EventHandler[U] {
+      override def handle(event: U): Unit = handler(event)
     }
   }
 
@@ -350,9 +352,9 @@ abstract class Node protected(override val delegate: jfxs.Node)
     onDragDetected() = v
   }
 
-  def onDragDetected_=[T >: jfxsi.MouseEvent <: jfxe.Event](handler: T => Unit) {
-    onDragDetected() = new jfxe.EventHandler[T] {
-      override def handle(event: T): Unit = handler(event)
+  def onDragDetected_=[T >: MouseEvent <: Event, U >: jfxsi.MouseEvent <: jfxe.Event](handler: T => Unit)(implicit jfx2sfx: U => T) {
+    onDragDetected() = new jfxe.EventHandler[U] {
+      override def handle(event: U): Unit = handler(event)
     }
   }
 
@@ -366,9 +368,9 @@ abstract class Node protected(override val delegate: jfxs.Node)
     onDragDone() = v
   }
 
-  def onDragDone_=[T >: jfxsi.DragEvent <: jfxe.Event](handler: T => Unit) {
-    onDragDone() = new jfxe.EventHandler[T] {
-      override def handle(event: T): Unit = handler(event)
+  def onDragDone_=[T >: DragEvent <: Event, U >: jfxsi.DragEvent <: jfxe.Event](handler: T => Unit)(implicit jfx2sfx: U => T) {
+    onDragDone() = new jfxe.EventHandler[U] {
+      override def handle(event: U): Unit = handler(event)
     }
   }
 
@@ -382,9 +384,9 @@ abstract class Node protected(override val delegate: jfxs.Node)
     onDragDropped() = v
   }
 
-  def onDragDropped_=[T >: jfxsi.DragEvent <: jfxe.Event](handler: T => Unit) {
-    onDragDropped() = new jfxe.EventHandler[T] {
-      override def handle(event: T): Unit = handler(event)
+  def onDragDropped_=[T >: DragEvent <: Event, U >: jfxsi.DragEvent <: jfxe.Event](handler: T => Unit)(implicit jfx2sfx: U => T) {
+    onDragDropped() = new jfxe.EventHandler[U] {
+      override def handle(event: U): Unit = handler(event)
     }
   }
 
@@ -397,9 +399,9 @@ abstract class Node protected(override val delegate: jfxs.Node)
     onDragEntered() = v
   }
 
-  def onDragEntered_=[T >: jfxsi.DragEvent <: jfxe.Event](handler: T => Unit) {
-    onDragEntered() = new jfxe.EventHandler[T] {
-      override def handle(event: T): Unit = handler(event)
+  def onDragEntered_=[T >: DragEvent <: Event, U >: jfxsi.DragEvent <: jfxe.Event](handler: T => Unit)(implicit jfx2sfx: U => T) {
+    onDragEntered() = new jfxe.EventHandler[U] {
+      override def handle(event: U): Unit = handler(event)
     }
   }
 
@@ -412,9 +414,9 @@ abstract class Node protected(override val delegate: jfxs.Node)
     onDragExited() = v
   }
 
-  def onDragExited_=[T >: jfxsi.DragEvent <: jfxe.Event](handler: T => Unit) {
-    onDragExited() = new jfxe.EventHandler[T] {
-      override def handle(event: T): Unit = handler(event)
+  def onDragExited_=[T >: DragEvent <: Event, U >: jfxsi.DragEvent <: jfxe.Event](handler: T => Unit)(implicit jfx2sfx: U => T) {
+    onDragExited() = new jfxe.EventHandler[U] {
+      override def handle(event: U): Unit = handler(event)
     }
   }
 
@@ -427,9 +429,9 @@ abstract class Node protected(override val delegate: jfxs.Node)
     onDragOver() = v
   }
 
-  def onDragOver_=[T >: jfxsi.DragEvent <: jfxe.Event](handler: T => Unit) {
-    onDragOver() = new jfxe.EventHandler[T] {
-      override def handle(event: T): Unit = handler(event)
+  def onDragOver_=[T >: DragEvent <: Event, U >: jfxsi.DragEvent <: jfxe.Event](handler: T => Unit)(implicit jfx2sfx: U => T) {
+    onDragOver() = new jfxe.EventHandler[U] {
+      override def handle(event: U): Unit = handler(event)
     }
   }
 
@@ -443,9 +445,10 @@ abstract class Node protected(override val delegate: jfxs.Node)
     onInputMethodTextChanged() = v
   }
 
-  def onInputMethodTextChanged_=[T >: jfxsi.InputMethodEvent <: jfxe.Event](handler: T => Unit) {
-    onInputMethodTextChanged() = new jfxe.EventHandler[T] {
-      override def handle(event: T): Unit = handler(event)
+  def onInputMethodTextChanged_=[T >: InputMethodEvent <: Event, U >: jfxsi.InputMethodEvent <: jfxe.Event](handler: T => Unit)
+                                                                                                           (implicit jfx2sfx: U => T) {
+    onInputMethodTextChanged() = new jfxe.EventHandler[U] {
+      override def handle(event: U): Unit = handler(event)
     }
   }
 
@@ -459,9 +462,9 @@ abstract class Node protected(override val delegate: jfxs.Node)
     onKeyPressed() = v
   }
 
-  def onKeyPressed_=[T >: jfxsi.KeyEvent <: jfxe.Event](handler: T => Unit) {
-    onKeyPressed() = new jfxe.EventHandler[T] {
-      override def handle(event: T): Unit = handler(event)
+  def onKeyPressed_=[T >: KeyEvent <: Event, U >: jfxsi.KeyEvent <: jfxe.Event](handler: T => Unit)(implicit jfx2sfx: U => T) {
+    onKeyPressed() = new jfxe.EventHandler[U] {
+      override def handle(event: U): Unit = handler(event)
     }
   }
 
@@ -475,9 +478,9 @@ abstract class Node protected(override val delegate: jfxs.Node)
     onKeyReleased() = v
   }
 
-  def onKeyReleased_=[T >: jfxsi.KeyEvent <: jfxe.Event](handler: T => Unit) {
-    onKeyReleased() = new jfxe.EventHandler[T] {
-      override def handle(event: T): Unit = handler(event)
+  def onKeyReleased_=[T >: KeyEvent <: Event, U >: jfxsi.KeyEvent <: jfxe.Event](handler: T => Unit)(implicit jfx2sfx: U => T) {
+    onKeyReleased() = new jfxe.EventHandler[U] {
+      override def handle(event: U): Unit = handler(event)
     }
   }
 
@@ -491,9 +494,9 @@ abstract class Node protected(override val delegate: jfxs.Node)
     onKeyTyped() = v
   }
 
-  def onKeyTyped_=[T >: jfxsi.KeyEvent <: jfxe.Event](handler: T => Unit) {
-    onKeyTyped() = new jfxe.EventHandler[T] {
-      override def handle(event: T): Unit = handler(event)
+  def onKeyTyped_=[T >: KeyEvent <: Event, U >: jfxsi.KeyEvent <: jfxe.Event](handler: T => Unit)(implicit jfx2sfx: U => T) {
+    onKeyTyped() = new jfxe.EventHandler[U] {
+      override def handle(event: U): Unit = handler(event)
     }
   }
 
@@ -507,9 +510,9 @@ abstract class Node protected(override val delegate: jfxs.Node)
     onMouseClicked() = v
   }
 
-  def onMouseClicked_=[T >: jfxsi.MouseEvent <: jfxe.Event](handler: T => Unit) {
-    onMouseClicked() = new jfxe.EventHandler[T] {
-      override def handle(event: T): Unit = handler(event)
+  def onMouseClicked_=[T >: MouseEvent <: Event, U >: jfxsi.MouseEvent <: jfxe.Event](handler: T => Unit)(implicit jfx2sfx: U => T) {
+    onMouseClicked() = new jfxe.EventHandler[U] {
+      override def handle(event: U): Unit = handler(event)
     }
   }
 
@@ -522,9 +525,9 @@ abstract class Node protected(override val delegate: jfxs.Node)
     onMouseDragged() = v
   }
 
-  def onMouseDragged_=[T >: jfxsi.MouseEvent <: jfxe.Event](handler: T => Unit) {
-    onMouseDragged() = new jfxe.EventHandler[T] {
-      override def handle(event: T): Unit = handler(event)
+  def onMouseDragged_=[T >: MouseEvent <: Event, U >: jfxsi.MouseEvent <: jfxe.Event](handler: T => Unit)(implicit jfx2sfx: U => T) {
+    onMouseDragged() = new jfxe.EventHandler[U] {
+      override def handle(event: U): Unit = handler(event)
     }
   }
 
@@ -537,9 +540,10 @@ abstract class Node protected(override val delegate: jfxs.Node)
     onMouseDragEntered() = v
   }
 
-  def onMouseDragEntered_=[T >: jfxsi.MouseDragEvent <: jfxe.Event](handler: T => Unit) {
-    onMouseDragEntered() = new jfxe.EventHandler[T] {
-      override def handle(event: T): Unit = handler(event)
+  def onMouseDragEntered_=[T >: MouseDragEvent <: Event, U >: jfxsi.MouseDragEvent <: jfxe.Event](handler: T => Unit)
+                                                                                                 (implicit jfx2sfx: U => T) {
+    onMouseDragEntered() = new jfxe.EventHandler[U] {
+      override def handle(event: U): Unit = handler(event)
     }
   }
 
@@ -552,9 +556,10 @@ abstract class Node protected(override val delegate: jfxs.Node)
     onMouseDragExited() = v
   }
 
-  def onMouseDragExited_=[T >: jfxsi.MouseDragEvent <: jfxe.Event](handler: T => Unit) {
-    onMouseDragExited() = new jfxe.EventHandler[T] {
-      override def handle(event: T): Unit = handler(event)
+  def onMouseDragExited_=[T >: MouseDragEvent <: Event, U >: jfxsi.MouseDragEvent <: jfxe.Event](handler: T => Unit)
+                                                                                                (implicit jfx2sfx: U => T) {
+    onMouseDragExited() = new jfxe.EventHandler[U] {
+      override def handle(event: U): Unit = handler(event)
     }
   }
 
@@ -567,9 +572,10 @@ abstract class Node protected(override val delegate: jfxs.Node)
     onMouseDragOver() = v
   }
 
-  def onMouseDragOver_=[T >: jfxsi.MouseDragEvent <: jfxe.Event](handler: T => Unit) {
-    onMouseDragOver() = new jfxe.EventHandler[T] {
-      override def handle(event: T): Unit = handler(event)
+  def onMouseDragOver_=[T >: MouseDragEvent <: Event, U >: jfxsi.MouseDragEvent <: jfxe.Event](handler: T => Unit)
+                                                                                              (implicit jfx2sfx: U => T) {
+    onMouseDragOver() = new jfxe.EventHandler[U] {
+      override def handle(event: U): Unit = handler(event)
     }
   }
 
@@ -583,9 +589,10 @@ abstract class Node protected(override val delegate: jfxs.Node)
     onMouseDragReleased() = v
   }
 
-  def onMouseDragReleased_=[T >: jfxsi.MouseDragEvent <: jfxe.Event](handler: T => Unit) {
-    onMouseDragReleased() = new jfxe.EventHandler[T] {
-      override def handle(event: T): Unit = handler(event)
+  def onMouseDragReleased_=[T >: MouseDragEvent <: Event, U >: jfxsi.MouseDragEvent <: jfxe.Event](handler: T => Unit)
+                                                                                                  (implicit jfx2sfx: U => T) {
+    onMouseDragReleased() = new jfxe.EventHandler[U] {
+      override def handle(event: U): Unit = handler(event)
     }
   }
 
@@ -598,9 +605,9 @@ abstract class Node protected(override val delegate: jfxs.Node)
     onMouseEntered() = v
   }
 
-  def onMouseEntered_=[T >: jfxsi.MouseEvent <: jfxe.Event](handler: T => Unit) {
-    onMouseEntered() = new jfxe.EventHandler[T] {
-      override def handle(event: T): Unit = handler(event)
+  def onMouseEntered_=[T >: MouseEvent <: Event, U >: jfxsi.MouseEvent <: jfxe.Event](handler: T => Unit)(implicit jfx2sfx: U => T) {
+    onMouseEntered() = new jfxe.EventHandler[U] {
+      override def handle(event: U): Unit = handler(event)
     }
   }
 
@@ -613,9 +620,9 @@ abstract class Node protected(override val delegate: jfxs.Node)
     onMouseExited() = v
   }
 
-  def onMouseExited_=[T >: jfxsi.MouseEvent <: jfxe.Event](handler: T => Unit) {
-    onMouseExited() = new jfxe.EventHandler[T] {
-      override def handle(event: T): Unit = handler(event)
+  def onMouseExited_=[T >: MouseEvent <: Event, U >: jfxsi.MouseEvent <: jfxe.Event](handler: T => Unit)(implicit jfx2sfx: U => T) {
+    onMouseExited() = new jfxe.EventHandler[U] {
+      override def handle(event: U): Unit = handler(event)
     }
   }
 
@@ -625,9 +632,9 @@ abstract class Node protected(override val delegate: jfxs.Node)
     onMouseMoved() = v
   }
 
-  def onMouseMoved_=[T >: jfxsi.MouseEvent <: jfxe.Event](handler: T => Unit) {
-    onMouseMoved() = new jfxe.EventHandler[T] {
-      override def handle(event: T): Unit = handler(event)
+  def onMouseMoved_=[T >: MouseEvent <: Event, U >: jfxsi.MouseEvent <: jfxe.Event](handler: T => Unit)(implicit jfx2sfx: U => T) {
+    onMouseMoved() = new jfxe.EventHandler[U] {
+      override def handle(event: U): Unit = handler(event)
     }
   }
 
@@ -640,9 +647,9 @@ abstract class Node protected(override val delegate: jfxs.Node)
     onMousePressed() = v
   }
 
-  def onMousePressed_=[T >: jfxsi.MouseEvent <: jfxe.Event](handler: T => Unit) {
-    onMousePressed() = new jfxe.EventHandler[T] {
-      override def handle(event: T): Unit = handler(event)
+  def onMousePressed_=[T >: MouseEvent <: Event, U >: jfxsi.MouseEvent <: jfxe.Event](handler: T => Unit)(implicit jfx2sfx: U => T) {
+    onMousePressed() = new jfxe.EventHandler[U] {
+      override def handle(event: U): Unit = handler(event)
     }
   }
 
@@ -655,9 +662,9 @@ abstract class Node protected(override val delegate: jfxs.Node)
     onMouseReleased() = v
   }
 
-  def onMouseReleased_=[T >: jfxsi.MouseEvent <: jfxe.Event](handler: T => Unit) {
-    onMouseReleased() = new jfxe.EventHandler[T] {
-      override def handle(event: T): Unit = handler(event)
+  def onMouseReleased_=[T >: MouseEvent <: Event, U >: jfxsi.MouseEvent <: jfxe.Event](handler: T => Unit)(implicit jfx2sfx: U => T) {
+    onMouseReleased() = new jfxe.EventHandler[U] {
+      override def handle(event: U): Unit = handler(event)
     }
   }
 
@@ -670,9 +677,9 @@ abstract class Node protected(override val delegate: jfxs.Node)
     onScroll() = v
   }
 
-  def onScroll_=[T >: jfxsi.ScrollEvent <: jfxe.Event](handler: T => Unit) {
-    onScroll() = new jfxe.EventHandler[T] {
-      override def handle(event: T): Unit = handler(event)
+  def onScroll_=[T >: ScrollEvent <: Event, U >: jfxsi.ScrollEvent <: jfxe.Event](handler: T => Unit)(implicit jfx2sfx: U => T) {
+    onScroll() = new jfxe.EventHandler[U] {
+      override def handle(event: U): Unit = handler(event)
     }
   }
 
@@ -1191,12 +1198,13 @@ abstract class Node protected(override val delegate: jfxs.Node)
    * @since 2.2
    */
   def onRotate = delegate.onRotateProperty
-  def onRotate_=(v: jfxe.EventHandler[jfxsi.RotateEvent]) {
+  def onRotate_=(v: jfxe.EventHandler[_ >:jfxsi.RotateEvent]) {
     onRotate() = v
   }
-  def onRotate_=(handler: jfxsi.RotateEvent => Unit) {
-    onRotate() = new jfxe.EventHandler[jfxsi.RotateEvent] {
-      override def handle(event: jfxsi.RotateEvent): Unit = handler(event)
+  def onRotate_=[T >: RotateEvent <: Event, U >: jfxsi.RotateEvent <: jfxe.Event](handler: T => Unit)
+                                                                                 (implicit jfx2sfx: U => T) {
+    onRotate() = new jfxe.EventHandler[U] {
+      override def handle(event: U): Unit = handler(event)
     }
   }
 
@@ -1206,12 +1214,13 @@ abstract class Node protected(override val delegate: jfxs.Node)
    * @since 2.2
    */
   def onRotationFinished = delegate.onRotationFinishedProperty()
-  def onRotationFinished_=(v: jfxe.EventHandler[jfxsi.RotateEvent]) {
+  def onRotationFinished_=(v: jfxe.EventHandler[_ >: jfxsi.RotateEvent]) {
     onRotationFinished() = v
   }
-  def onRotationFinished_=(handler: jfxsi.RotateEvent => Unit) {
-    onRotationFinished() = new jfxe.EventHandler[jfxsi.RotateEvent] {
-      override def handle(event: jfxsi.RotateEvent): Unit = handler(event)
+  def onRotationFinished_=[T >: RotateEvent <: Event, U >: jfxsi.RotateEvent <: jfxe.Event](handler: T => Unit)
+                                                                                           (implicit jfx2sfx: U => T) {
+    onRotationFinished() = new jfxe.EventHandler[U] {
+      override def handle(event: U): Unit = handler(event)
     }
   }
 
@@ -1221,12 +1230,13 @@ abstract class Node protected(override val delegate: jfxs.Node)
    * @since 2.2
    */
   def onRotationStarted = delegate.onRotationFinishedProperty()
-  def onRotationStarted_=(v: jfxe.EventHandler[jfxsi.RotateEvent]) {
+  def onRotationStarted_=(v: jfxe.EventHandler[_ >: jfxsi.RotateEvent]) {
     onRotationStarted() = v
   }
-  def onRotationStarted_=(handler: jfxsi.RotateEvent => Unit) {
-    onRotationStarted() = new jfxe.EventHandler[jfxsi.RotateEvent] {
-      override def handle(event: jfxsi.RotateEvent): Unit = handler(event)
+  def onRotationStarted_=[T >: RotateEvent <: Event, U >: jfxsi.RotateEvent <: jfxe.Event](handler: T => Unit)
+                                                                                          (implicit jfx2sfx: U => T) {
+    onRotationStarted() = new jfxe.EventHandler[U] {
+      override def handle(event: U): Unit = handler(event)
     }
   }
 
@@ -1236,12 +1246,13 @@ abstract class Node protected(override val delegate: jfxs.Node)
    * @since 2.2
    */
   def onScrollFinished = delegate.onScrollFinishedProperty()
-  def onScrollFinished_=(v: jfxe.EventHandler[jfxsi.ScrollEvent]) {
+  def onScrollFinished_=(v: jfxe.EventHandler[_ >: jfxsi.ScrollEvent]) {
     onScrollFinished() = v
   }
-  def onScrollFinished_=(handler: jfxsi.ScrollEvent => Unit) {
-    onScrollFinished() = new jfxe.EventHandler[jfxsi.ScrollEvent] {
-      override def handle(event: jfxsi.ScrollEvent): Unit = handler(event)
+  def onScrollFinished_=[T >: ScrollEvent <: Event, U >: jfxsi.ScrollEvent <: jfxe.Event](handler: T => Unit)
+                                                                                         (implicit jfx2sfx: U => T) {
+    onScrollFinished() = new jfxe.EventHandler[U] {
+      override def handle(event: U): Unit = handler(event)
     }
   }
 
@@ -1251,12 +1262,13 @@ abstract class Node protected(override val delegate: jfxs.Node)
    * @since 2.2
    */
   def onScrollStarted = delegate.onScrollStartedProperty()
-  def onScrollStarted_=(v: jfxe.EventHandler[jfxsi.ScrollEvent]) {
+  def onScrollStarted_=(v: jfxe.EventHandler[_ >: jfxsi.ScrollEvent]) {
     onScrollStarted() = v
   }
-  def onScrollStarted_=(handler: jfxsi.ScrollEvent => Unit) {
-    onScrollStarted() = new jfxe.EventHandler[jfxsi.ScrollEvent] {
-      override def handle(event: jfxsi.ScrollEvent): Unit = handler(event)
+  def onScrollStarted_=[T >: ScrollEvent <: Event, U >: jfxsi.ScrollEvent <: jfxe.Event](handler: T => Unit)
+                                                                                        (implicit jfx2sfx: U => T) {
+    onScrollStarted() = new jfxe.EventHandler[U] {
+      override def handle(event: U): Unit = handler(event)
     }
   }
 
@@ -1266,12 +1278,13 @@ abstract class Node protected(override val delegate: jfxs.Node)
    * @since 2.2
    */
   def onSwipeDown = delegate.onSwipeDownProperty()
-  def onSwipeDown_=(v: jfxe.EventHandler[jfxsi.SwipeEvent]) {
+  def onSwipeDown_=(v: jfxe.EventHandler[_ >: jfxsi.SwipeEvent]) {
     onSwipeDown() = v
   }
-  def onSwipeDown_=(handler: jfxsi.SwipeEvent => Unit) {
-    onSwipeDown() = new jfxe.EventHandler[jfxsi.SwipeEvent] {
-      override def handle(event: jfxsi.SwipeEvent): Unit = handler(event)
+  def onSwipeDown_=[T >: SwipeEvent <: Event, U >: jfxsi.SwipeEvent <: jfxe.Event](handler: T => Unit)
+                                                                                  (implicit jfx2sfx: U => T) {
+    onSwipeDown() = new jfxe.EventHandler[U] {
+      override def handle(event: U): Unit = handler(event)
     }
   }
 
@@ -1281,12 +1294,13 @@ abstract class Node protected(override val delegate: jfxs.Node)
    * @since 2.2
    */
   def onSwipeLeft = delegate.onSwipeLeftProperty()
-  def onSwipeLeft_=(v: jfxe.EventHandler[jfxsi.SwipeEvent]) {
+  def onSwipeLeft_=(v: jfxe.EventHandler[_ >: jfxsi.SwipeEvent]) {
     onSwipeLeft() = v
   }
-  def onSwipeLeft_=(handler: jfxsi.SwipeEvent => Unit) {
-    onSwipeLeft() = new jfxe.EventHandler[jfxsi.SwipeEvent] {
-      override def handle(event: jfxsi.SwipeEvent): Unit = handler(event)
+  def onSwipeLeft_=[T >: SwipeEvent <: Event, U >: jfxsi.SwipeEvent <: jfxe.Event](handler: T => Unit)
+                                                                                  (implicit jfx2sfx: U => T) {
+    onSwipeLeft() = new jfxe.EventHandler[U] {
+      override def handle(event: U): Unit = handler(event)
     }
   }
 
@@ -1296,12 +1310,13 @@ abstract class Node protected(override val delegate: jfxs.Node)
    * @since 2.2
    */
   def onSwipeUp = delegate.onSwipeUpProperty()
-  def onSwipeUp_=(v: jfxe.EventHandler[jfxsi.SwipeEvent]) {
+  def onSwipeUp_=(v: jfxe.EventHandler[_ >: jfxsi.SwipeEvent]) {
     onSwipeUp() = v
   }
-  def onSwipeUp_=(handler: jfxsi.SwipeEvent => Unit) {
-    onSwipeUp() = new jfxe.EventHandler[jfxsi.SwipeEvent] {
-      override def handle(event: jfxsi.SwipeEvent): Unit = handler(event)
+  def onSwipeUp_=[T >: SwipeEvent <: Event, U >: jfxsi.SwipeEvent <: jfxe.Event](handler: T => Unit)
+                                                                                (implicit jfx2sfx: U => T) {
+    onSwipeUp() = new jfxe.EventHandler[U] {
+      override def handle(event: U): Unit = handler(event)
     }
   }
 
@@ -1311,12 +1326,13 @@ abstract class Node protected(override val delegate: jfxs.Node)
    * @since 2.2
    */
   def onSwipeRight = delegate.onSwipeRightProperty()
-  def onSwipeRight_=(v: jfxe.EventHandler[jfxsi.SwipeEvent]) {
+  def onSwipeRight_=(v: jfxe.EventHandler[_ >: jfxsi.SwipeEvent]) {
     onSwipeRight() = v
   }
-  def onSwipeRight_=(handler: jfxsi.SwipeEvent => Unit) {
-    onSwipeRight() = new jfxe.EventHandler[jfxsi.SwipeEvent] {
-      override def handle(event: jfxsi.SwipeEvent): Unit = handler(event)
+  def onSwipeRight_=[T >: SwipeEvent <: Event, U >: jfxsi.SwipeEvent <: jfxe.Event](handler: T => Unit)
+                                                                                   (implicit jfx2sfx: U => T) {
+    onSwipeRight() = new jfxe.EventHandler[U] {
+      override def handle(event: U): Unit = handler(event)
     }
   }
 
@@ -1326,12 +1342,13 @@ abstract class Node protected(override val delegate: jfxs.Node)
    * @since 2.2
    */
   def onZoom = delegate.onZoomProperty()
-  def onZoom_=(v: jfxe.EventHandler[jfxsi.ZoomEvent]) {
+  def onZoom_=(v: jfxe.EventHandler[_ >: jfxsi.ZoomEvent]) {
     onZoom() = v
   }
-  def onZoom_=(handler: jfxsi.ZoomEvent => Unit) {
-    onZoom() = new jfxe.EventHandler[jfxsi.ZoomEvent] {
-      override def handle(event: jfxsi.ZoomEvent): Unit = handler(event)
+  def onZoom_=[T >: ZoomEvent <: Event, U >: jfxsi.ZoomEvent <: jfxe.Event](handler: T => Unit)
+                                                                           (implicit jfx2sfx: U => T) {
+    onZoom() = new jfxe.EventHandler[U] {
+      override def handle(event: U): Unit = handler(event)
     }
   }
 
@@ -1344,9 +1361,10 @@ abstract class Node protected(override val delegate: jfxs.Node)
   def onZoomFinished_=(v: jfxe.EventHandler[jfxsi.ZoomEvent]) {
     onZoomFinished() = v
   }
-  def onZoomFinished_=(handler: jfxsi.ZoomEvent => Unit) {
-    onZoomFinished() = new jfxe.EventHandler[jfxsi.ZoomEvent] {
-      override def handle(event: jfxsi.ZoomEvent): Unit = handler(event)
+  def onZoomFinished_=[T >: ZoomEvent <: Event, U >: jfxsi.ZoomEvent <: jfxe.Event](handler: T => Unit)
+                                                                                   (implicit jfx2sfx: U => T) {
+    onZoomFinished() = new jfxe.EventHandler[U] {
+      override def handle(event: U): Unit = handler(event)
     }
   }
 
@@ -1359,9 +1377,10 @@ abstract class Node protected(override val delegate: jfxs.Node)
   def onZoomStarted_=(v: jfxe.EventHandler[jfxsi.ZoomEvent]) {
     onZoomStarted() = v
   }
-  def onZoomStarted_=(handler: jfxsi.ZoomEvent => Unit) {
-    onZoomStarted() = new jfxe.EventHandler[jfxsi.ZoomEvent] {
-      override def handle(event: jfxsi.ZoomEvent): Unit = handler(event)
+  def onZoomStarted_=[T >: ZoomEvent <: Event, U >: jfxsi.ZoomEvent <: jfxe.Event](handler: T => Unit)
+                                                                                  (implicit jfx2sfx: U => T) {
+    onZoomStarted() = new jfxe.EventHandler[U] {
+      override def handle(event: U): Unit = handler(event)
     }
   }
 
@@ -1371,12 +1390,13 @@ abstract class Node protected(override val delegate: jfxs.Node)
    * @since 2.2
    */
   def onTouchMoved = delegate.onTouchMovedProperty()
-  def onTouchMoved_=(v: jfxe.EventHandler[jfxsi.TouchEvent]) {
+  def onTouchMoved_=(v: jfxe.EventHandler[_ >: jfxsi.TouchEvent]) {
     onTouchMoved() = v
   }
-  def onTouchMoved_=(handler: jfxsi.TouchEvent => Unit) {
-    onTouchMoved() = new jfxe.EventHandler[jfxsi.TouchEvent] {
-      override def handle(event: jfxsi.TouchEvent): Unit = handler(event)
+  def onTouchMoved_=[T >: TouchEvent <: Event, U >: jfxsi.TouchEvent <: jfxe.Event](handler: T => Unit)
+                                                                                   (implicit jfx2sfx: U => T) {
+    onTouchMoved() = new jfxe.EventHandler[U] {
+      override def handle(event: U): Unit = handler(event)
     }
   }
 
@@ -1386,12 +1406,13 @@ abstract class Node protected(override val delegate: jfxs.Node)
    * @since 2.2
    */
   def onTouchPressed = delegate.onTouchPressedProperty()
-  def onTouchPressed_=(v: jfxe.EventHandler[jfxsi.TouchEvent]) {
+  def onTouchPressed_=(v: jfxe.EventHandler[_ >: jfxsi.TouchEvent]) {
     onTouchPressed() = v
   }
-  def onTouchPressed_=(handler: jfxsi.TouchEvent => Unit) {
-    onTouchPressed() = new jfxe.EventHandler[jfxsi.TouchEvent] {
-      override def handle(event: jfxsi.TouchEvent): Unit = handler(event)
+  def onTouchPressed_=[T >: TouchEvent <: Event, U >: jfxsi.TouchEvent <: jfxe.Event](handler: T => Unit)
+                                                                                     (implicit jfx2sfx: U => T) {
+    onTouchPressed() = new jfxe.EventHandler[U] {
+      override def handle(event: U): Unit = handler(event)
     }
   }
 
@@ -1401,12 +1422,13 @@ abstract class Node protected(override val delegate: jfxs.Node)
    * @since 2.2
    */
   def onTouchReleased = delegate.onTouchReleasedProperty()
-  def onTouchReleased_=(v: jfxe.EventHandler[jfxsi.TouchEvent]) {
+  def onTouchReleased_=(v: jfxe.EventHandler[_ >: jfxsi.TouchEvent]) {
     onTouchReleased() = v
   }
-  def onTouchReleased_=(handler: jfxsi.TouchEvent => Unit) {
-    onTouchReleased() = new jfxe.EventHandler[jfxsi.TouchEvent] {
-      override def handle(event: jfxsi.TouchEvent): Unit = handler(event)
+  def onTouchReleased_=[T >: TouchEvent <: Event, U >: jfxsi.TouchEvent <: jfxe.Event](handler: T => Unit)
+                                                                                      (implicit jfx2sfx: U => T) {
+    onTouchReleased() = new jfxe.EventHandler[U] {
+      override def handle(event: U): Unit = handler(event)
     }
   }
 
@@ -1416,12 +1438,13 @@ abstract class Node protected(override val delegate: jfxs.Node)
    * @since 2.2
    */
   def onTouchStationary = delegate.onTouchStationaryProperty()
-  def onTouchStationary_=(v: jfxe.EventHandler[jfxsi.TouchEvent]) {
+  def onTouchStationary_=(v: jfxe.EventHandler[_ >: jfxsi.TouchEvent]) {
     onTouchStationary() = v
   }
-  def onTouchStationary_=(handler: jfxsi.TouchEvent => Unit) {
-    onTouchStationary() = new jfxe.EventHandler[jfxsi.TouchEvent] {
-      override def handle(event: jfxsi.TouchEvent): Unit = handler(event)
+  def onTouchStationary_=[T >: TouchEvent <: Event, U >: jfxsi.TouchEvent <: jfxe.Event](handler: T => Unit)
+                                                                                        (implicit jfx2sfx: U => T) {
+    onTouchStationary() = new jfxe.EventHandler[U] {
+      override def handle(event: U): Unit = handler(event)
     }
   }
 

--- a/scalafx/src/main/scala/scalafx/scene/Scene.scala
+++ b/scalafx/src/main/scala/scalafx/scene/Scene.scala
@@ -253,6 +253,11 @@ class Scene(override val delegate: jfxs.Scene = new jfxs.Scene(new jfxs.Group())
   def onContextMenuRequested_=(v: jfxe.EventHandler[_ >: jfxsi.ContextMenuEvent]) {
     onContextMenuRequested() = v
   }
+  def onContextMenuRequested_=[T >: jfxsi.ContextMenuEvent <: jfxe.Event](handler: T => Unit) {
+    onContextMenuRequested() = new jfxe.EventHandler[T] {
+      override def handle(event: T): Unit = handler(event)
+    }
+  }
 
   /**
    * Defines a function to be called when drag gesture has been detected.
@@ -260,6 +265,11 @@ class Scene(override val delegate: jfxs.Scene = new jfxs.Scene(new jfxs.Group())
   def onDragDetected = delegate.onDragDetectedProperty
   def onDragDetected_=(v: jfxe.EventHandler[_ >: jfxsi.MouseEvent]) {
     onDragDetected() = v
+  }
+  def onDragDetected_=[T >: jfxsi.MouseEvent <: jfxe.Event](handler: T => Unit) {
+    onDragDetected() = new jfxe.EventHandler[T] {
+      override def handle(event: T): Unit = handler(event)
+    }
   }
 
   /**
@@ -270,6 +280,11 @@ class Scene(override val delegate: jfxs.Scene = new jfxs.Scene(new jfxs.Group())
   def onDragDone_=(v: jfxe.EventHandler[_ >: jfxsi.DragEvent]) {
     onDragDone() = v
   }
+  def onDragDone_=[T >: jfxsi.DragEvent <: jfxe.Event](handler: T => Unit) {
+    onDragDone() = new jfxe.EventHandler[T] {
+      override def handle(event: T): Unit = handler(event)
+    }
+  }
 
   /**
    * Defines a function to be called when the mouse button is released on this `Scene` during drag and drop gesture.
@@ -277,6 +292,11 @@ class Scene(override val delegate: jfxs.Scene = new jfxs.Scene(new jfxs.Group())
   def onDragDropped = delegate.onDragDroppedProperty
   def onDragDropped_=(v: jfxe.EventHandler[_ >: jfxsi.DragEvent]) {
     onDragDropped() = v
+  }
+  def onDragDropped_=[T >: jfxsi.DragEvent <: jfxe.Event](handler: T => Unit) {
+    onDragDropped() = new jfxe.EventHandler[T] {
+      override def handle(event: T): Unit = handler(event)
+    }
   }
 
   /**
@@ -286,6 +306,11 @@ class Scene(override val delegate: jfxs.Scene = new jfxs.Scene(new jfxs.Group())
   def onDragEntered_=(v: jfxe.EventHandler[_ >: jfxsi.DragEvent]) {
     onDragEntered() = v
   }
+  def onDragEntered_=[T >: jfxsi.DragEvent <: jfxe.Event](handler: T => Unit) {
+    onDragEntered() = new jfxe.EventHandler[T] {
+      override def handle(event: T): Unit = handler(event)
+    }
+  }
 
   /**
    * Defines a function to be called when drag gesture exits this Scene.
@@ -293,6 +318,11 @@ class Scene(override val delegate: jfxs.Scene = new jfxs.Scene(new jfxs.Group())
   def onDragExited = delegate.onDragExitedProperty
   def onDragExited_=(v: jfxe.EventHandler[_ >: jfxsi.DragEvent]) {
     onDragExited() = v
+  }
+  def onDragExited_=[T >: jfxsi.DragEvent <: jfxe.Event](handler: T => Unit) {
+    onDragExited() = new jfxe.EventHandler[T] {
+      override def handle(event: T): Unit = handler(event)
+    }
   }
 
   /**
@@ -302,6 +332,11 @@ class Scene(override val delegate: jfxs.Scene = new jfxs.Scene(new jfxs.Group())
   def onDragOver_=(v: jfxe.EventHandler[_ >: jfxsi.DragEvent]) {
     onDragOver() = v
   }
+  def onDragOver_=[T >: jfxsi.DragEvent <: jfxe.Event](handler: T => Unit) {
+    onDragOver() = new jfxe.EventHandler[T] {
+      override def handle(event: T): Unit = handler(event)
+    }
+  }
 
   /**
    * Defines a function to be called when this `Node` has input focus and the input method text has changed.
@@ -309,6 +344,11 @@ class Scene(override val delegate: jfxs.Scene = new jfxs.Scene(new jfxs.Group())
   def onInputMethodTextChanged = delegate.onInputMethodTextChangedProperty
   def onInputMethodTextChanged_=(v: jfxe.EventHandler[_ >: jfxsi.InputMethodEvent]) {
     onInputMethodTextChanged() = v
+  }
+  def onInputMethodTextChanged_=[T >: jfxsi.InputMethodEvent <: jfxe.Event](handler: T => Unit) {
+    onInputMethodTextChanged() = new jfxe.EventHandler[T] {
+      override def handle(event: T): Unit = handler(event)
+    }
   }
 
   /**
@@ -318,6 +358,11 @@ class Scene(override val delegate: jfxs.Scene = new jfxs.Scene(new jfxs.Group())
   def onKeyPressed_=(v: jfxe.EventHandler[_ >: jfxsi.KeyEvent]) {
     onKeyPressed() = v
   }
+  def onKeyPressed_=[T >: jfxsi.KeyEvent <: jfxe.Event](handler: T => Unit) {
+    onKeyPressed() = new jfxe.EventHandler[T] {
+      override def handle(event: T): Unit = handler(event)
+    }
+  }
 
   /**
    * Defines a function to be called when some `Node` of this `Scene` has input focus and a key has been released.
@@ -325,6 +370,11 @@ class Scene(override val delegate: jfxs.Scene = new jfxs.Scene(new jfxs.Group())
   def onKeyReleased = delegate.onKeyReleasedProperty
   def onKeyReleased_=(v: jfxe.EventHandler[_ >: jfxsi.KeyEvent]) {
     onKeyReleased() = v
+  }
+  def onKeyReleased_=[T >: jfxsi.KeyEvent <: jfxe.Event](handler: T => Unit) {
+    onKeyReleased() = new jfxe.EventHandler[T] {
+      override def handle(event: T): Unit = handler(event)
+    }
   }
 
   /**
@@ -334,6 +384,11 @@ class Scene(override val delegate: jfxs.Scene = new jfxs.Scene(new jfxs.Group())
   def onKeyTyped_=(v: jfxe.EventHandler[_ >: jfxsi.KeyEvent]) {
     onKeyTyped() = v
   }
+  def onKeyTyped_=[T >: jfxsi.KeyEvent <: jfxe.Event](handler: T => Unit) {
+    onKeyTyped() = new jfxe.EventHandler[T] {
+      override def handle(event: T): Unit = handler(event)
+    }
+  }
 
   /**
    * Defines a function to be called when a mouse button has been clicked (pressed and released) on this `Scene`.
@@ -341,6 +396,11 @@ class Scene(override val delegate: jfxs.Scene = new jfxs.Scene(new jfxs.Group())
   def onMouseClicked = delegate.onMouseClickedProperty
   def onMouseClicked_=(v: jfxe.EventHandler[_ >: jfxsi.MouseEvent]) {
     onMouseClicked() = v
+  }
+  def onMouseClicked_=[T >: jfxsi.MouseEvent <: jfxe.Event](handler: T => Unit) {
+    onMouseClicked() = new jfxe.EventHandler[T] {
+      override def handle(event: T): Unit = handler(event)
+    }
   }
 
   /**
@@ -350,37 +410,62 @@ class Scene(override val delegate: jfxs.Scene = new jfxs.Scene(new jfxs.Group())
   def onMouseDragged_=(v: jfxe.EventHandler[_ >: jfxsi.MouseEvent]) {
     onMouseDragged() = v
   }
+  def onMouseDragged_=[T >: jfxsi.MouseEvent <: jfxe.Event](handler: T => Unit) {
+    onMouseDragged() = new jfxe.EventHandler[T] {
+      override def handle(event: T): Unit = handler(event)
+    }
+  }
 
   /**
    * Defines a function to be called when a full press-drag-release gesture enters this `Scene`.
    */
   def onMouseDragEntered = delegate.onMouseDragEnteredProperty
-  def onMouseDragEntered_=(v: jfxe.EventHandler[_ >: jfxsi.MouseEvent]) {
+  def onMouseDragEntered_=(v: jfxe.EventHandler[_ >: jfxsi.MouseDragEvent]) {
     onMouseDragEntered() = v
+  }
+  def onMouseDragEntered_=[T >: jfxsi.MouseDragEvent <: jfxe.Event](handler: T => Unit) {
+    onMouseDragEntered() = new jfxe.EventHandler[T] {
+      override def handle(event: T): Unit = handler(event)
+    }
   }
 
   /**
    * Defines a function to be called when a full press-drag-release gesture exits this `Scene`.
    */
   def onMouseDragExited = delegate.onMouseDragExitedProperty
-  def onMouseDragExited_=(v: jfxe.EventHandler[_ >: jfxsi.MouseEvent]) {
+  def onMouseDragExited_=(v: jfxe.EventHandler[_ >: jfxsi.MouseDragEvent]) {
     onMouseDragExited() = v
+  }
+  def onMouseDragExited_=[T >: jfxsi.MouseDragEvent <: jfxe.Event](handler: T => Unit) {
+    onMouseDragExited() = new jfxe.EventHandler[T] {
+      override def handle(event: T): Unit = handler(event)
+    }
   }
 
   /**
    * Defines a function to be called when a full press-drag-release gesture progresses within this `Scene`.
    */
   def onMouseDragOver = delegate.onMouseDragOverProperty
-  def onMouseDragOver_=(v: jfxe.EventHandler[_ >: jfxsi.MouseEvent]) {
+  def onMouseDragOver_=(v: jfxe.EventHandler[_ >: jfxsi.MouseDragEvent]) {
     onMouseDragOver() = v
+  }
+  def onMouseDragOver_=[T >: jfxsi.MouseDragEvent <: jfxe.Event](handler: T => Unit) {
+    onMouseDragOver() = new jfxe.EventHandler[T] {
+      override def handle(event: T): Unit = handler(event)
+    }
   }
 
   /**
    * Defines a function to be called when a full press-drag-release gesture ends within this `Scene`.
    */
   def onMouseDragReleased = delegate.onMouseDragReleasedProperty
-  def onMouseDragReleased_=(v: jfxe.EventHandler[_ >: jfxsi.MouseEvent]) {
+  def onMouseDragReleased_=(v: jfxe.EventHandler[_ >: jfxsi.MouseDragEvent]) {
     onMouseDragReleased() = v
+  }
+  def onMouseDragReleased_=[T >: jfxsi.MouseDragEvent <: jfxe.Event](handler: T => Unit) {
+    onMouseDragReleased() = new jfxe.EventHandler[T] {
+      override def handle(event: T): Unit = handler(event)
+    }
   }
 
   /**
@@ -390,6 +475,11 @@ class Scene(override val delegate: jfxs.Scene = new jfxs.Scene(new jfxs.Group())
   def onMouseEntered_=(v: jfxe.EventHandler[_ >: jfxsi.MouseEvent]) {
     onMouseEntered() = v
   }
+  def onMouseEntered_=[T >: jfxsi.MouseEvent <: jfxe.Event](handler: T => Unit) {
+    onMouseEntered() = new jfxe.EventHandler[T] {
+      override def handle(event: T): Unit = handler(event)
+    }
+  }
 
   /**
    * Defines a function to be called when the mouse exits this `Scene`.
@@ -397,6 +487,11 @@ class Scene(override val delegate: jfxs.Scene = new jfxs.Scene(new jfxs.Group())
   def onMouseExited = delegate.onMouseExitedProperty
   def onMouseExited_=(v: jfxe.EventHandler[_ >: jfxsi.MouseEvent]) {
     onMouseExited() = v
+  }
+  def onMouseExited_=[T >: jfxsi.MouseEvent <: jfxe.Event](handler: T => Unit) {
+    onMouseExited() = new jfxe.EventHandler[T] {
+      override def handle(event: T): Unit = handler(event)
+    }
   }
 
   /**
@@ -406,13 +501,24 @@ class Scene(override val delegate: jfxs.Scene = new jfxs.Scene(new jfxs.Group())
   def onMouseMoved_=(v: jfxe.EventHandler[_ >: jfxsi.MouseEvent]) {
     onMouseMoved() = v
   }
+  def onMouseMoved_=[T >: jfxsi.MouseEvent <: jfxe.Event](handler: T => Unit) {
+    onMouseMoved() = new jfxe.EventHandler[T] {
+      override def handle(event: T): Unit = handler(event)
+    }
+  }
 
   /**
-   * Defines a function to be called when a mouse button has been pressed on this `Scene`.
+   * Defines a function to be called when a mouse button has been pressed on this
+   * `Scene`.
    */
   def onMousePressed = delegate.onMousePressedProperty
   def onMousePressed_=(v: jfxe.EventHandler[_ >: jfxsi.MouseEvent]) {
     onMousePressed() = v
+  }
+  def onMousePressed_=[T >: jfxsi.MouseEvent <: jfxe.Event](handler: T => Unit) {
+    onMousePressed() = new jfxe.EventHandler[T] {
+      override def handle(event: T): Unit = handler(event)
+    }
   }
 
   /**
@@ -422,6 +528,11 @@ class Scene(override val delegate: jfxs.Scene = new jfxs.Scene(new jfxs.Group())
   def onMouseReleased_=(v: jfxe.EventHandler[_ >: jfxsi.MouseEvent]) {
     onMouseReleased() = v
   }
+  def onMouseReleased_=[T >: jfxsi.MouseEvent <: jfxe.Event](handler: T => Unit) {
+    onMouseReleased() = new jfxe.EventHandler[T] {
+      override def handle(event: T): Unit = handler(event)
+    }
+  }
 
   /**
    * Defines a function to be called when user performs a scrolling action.
@@ -429,6 +540,11 @@ class Scene(override val delegate: jfxs.Scene = new jfxs.Scene(new jfxs.Group())
   def onScroll = delegate.onScrollProperty
   def onScroll_=(v: jfxe.EventHandler[_ >: jfxsi.ScrollEvent]) {
     onScroll() = v
+  }
+  def onScroll_=[T >: jfxsi.ScrollEvent <: jfxe.Event](handler: T => Unit) {
+    onScroll() = new jfxe.EventHandler[T] {
+      override def handle(event: T): Unit = handler(event)
+    }
   }
 
   /**
@@ -564,6 +680,11 @@ class Scene(override val delegate: jfxs.Scene = new jfxs.Scene(new jfxs.Group())
   def onRotate_=(v: jfxe.EventHandler[jfxsi.RotateEvent]) {
     onRotate() = v
   }
+  def onRotate_=(handler: jfxsi.RotateEvent => Unit) {
+    onRotate() = new jfxe.EventHandler[jfxsi.RotateEvent] {
+      override def handle(event: jfxsi.RotateEvent): Unit = handler(event)
+    }
+  }
 
   /**
    * Defines a function to be called when a rotation gesture ends.
@@ -573,6 +694,11 @@ class Scene(override val delegate: jfxs.Scene = new jfxs.Scene(new jfxs.Group())
   def onRotationFinished = delegate.onRotationFinishedProperty()
   def onRotationFinished_=(v: jfxe.EventHandler[jfxsi.RotateEvent]) {
     onRotationFinished() = v
+  }
+  def onRotationFinished_=(handler: jfxsi.RotateEvent => Unit) {
+    onRotationFinished() = new jfxe.EventHandler[jfxsi.RotateEvent] {
+      override def handle(event: jfxsi.RotateEvent): Unit = handler(event)
+    }
   }
 
   /**
@@ -584,6 +710,11 @@ class Scene(override val delegate: jfxs.Scene = new jfxs.Scene(new jfxs.Group())
   def onRotationStarted_=(v: jfxe.EventHandler[jfxsi.RotateEvent]) {
     onRotationStarted() = v
   }
+  def onRotationStarted_=(handler: jfxsi.RotateEvent => Unit) {
+    onRotationStarted() = new jfxe.EventHandler[jfxsi.RotateEvent] {
+      override def handle(event: jfxsi.RotateEvent): Unit = handler(event)
+    }
+  }
 
   /**
    * Defines a function to be called when a Scroll gesture ends.
@@ -593,6 +724,11 @@ class Scene(override val delegate: jfxs.Scene = new jfxs.Scene(new jfxs.Group())
   def onScrollFinished = delegate.onScrollFinishedProperty()
   def onScrollFinished_=(v: jfxe.EventHandler[jfxsi.ScrollEvent]) {
     onScrollFinished() = v
+  }
+  def onScrollFinished_=(handler: jfxsi.ScrollEvent => Unit) {
+    onScrollFinished() = new jfxe.EventHandler[jfxsi.ScrollEvent] {
+      override def handle(event: jfxsi.ScrollEvent): Unit = handler(event)
+    }
   }
 
   /**
@@ -604,6 +740,11 @@ class Scene(override val delegate: jfxs.Scene = new jfxs.Scene(new jfxs.Group())
   def onScrollStarted_=(v: jfxe.EventHandler[jfxsi.ScrollEvent]) {
     onScrollStarted() = v
   }
+  def onScrollStarted_=(handler: jfxsi.ScrollEvent => Unit) {
+    onScrollStarted() = new jfxe.EventHandler[jfxsi.ScrollEvent] {
+      override def handle(event: jfxsi.ScrollEvent): Unit = handler(event)
+    }
+  }
 
   /**
    * Defines a function to be called when a Swipe Down gesture starts.
@@ -613,6 +754,11 @@ class Scene(override val delegate: jfxs.Scene = new jfxs.Scene(new jfxs.Group())
   def onSwipeDown = delegate.onSwipeDownProperty()
   def onSwipeDown_=(v: jfxe.EventHandler[jfxsi.SwipeEvent]) {
     onSwipeDown() = v
+  }
+  def onSwipeDown_=(handler: jfxsi.SwipeEvent => Unit) {
+    onSwipeDown() = new jfxe.EventHandler[jfxsi.SwipeEvent] {
+      override def handle(event: jfxsi.SwipeEvent): Unit = handler(event)
+    }
   }
 
   /**
@@ -624,6 +770,11 @@ class Scene(override val delegate: jfxs.Scene = new jfxs.Scene(new jfxs.Group())
   def onSwipeLeft_=(v: jfxe.EventHandler[jfxsi.SwipeEvent]) {
     onSwipeLeft() = v
   }
+  def onSwipeLeft_=(handler: jfxsi.SwipeEvent => Unit) {
+    onSwipeLeft() = new jfxe.EventHandler[jfxsi.SwipeEvent] {
+      override def handle(event: jfxsi.SwipeEvent): Unit = handler(event)
+    }
+  }
 
   /**
    * Defines a function to be called when a Swipe Up gesture starts.
@@ -633,6 +784,11 @@ class Scene(override val delegate: jfxs.Scene = new jfxs.Scene(new jfxs.Group())
   def onSwipeUp = delegate.onSwipeUpProperty()
   def onSwipeUp_=(v: jfxe.EventHandler[jfxsi.SwipeEvent]) {
     onSwipeUp() = v
+  }
+  def onSwipeUp_=(handler: jfxsi.SwipeEvent => Unit) {
+    onSwipeUp() = new jfxe.EventHandler[jfxsi.SwipeEvent] {
+      override def handle(event: jfxsi.SwipeEvent): Unit = handler(event)
+    }
   }
 
   /**
@@ -644,6 +800,11 @@ class Scene(override val delegate: jfxs.Scene = new jfxs.Scene(new jfxs.Group())
   def onSwipeRight_=(v: jfxe.EventHandler[jfxsi.SwipeEvent]) {
     onSwipeRight() = v
   }
+  def onSwipeRight_=(handler: jfxsi.SwipeEvent => Unit) {
+    onSwipeRight() = new jfxe.EventHandler[jfxsi.SwipeEvent] {
+      override def handle(event: jfxsi.SwipeEvent): Unit = handler(event)
+    }
+  }
 
   /**
    * Defines a function to be called when user performs a Touch action.
@@ -653,6 +814,11 @@ class Scene(override val delegate: jfxs.Scene = new jfxs.Scene(new jfxs.Group())
   def onZoom = delegate.onZoomProperty()
   def onZoom_=(v: jfxe.EventHandler[jfxsi.ZoomEvent]) {
     onZoom() = v
+  }
+  def onZoom_=(handler: jfxsi.ZoomEvent => Unit) {
+    onZoom() = new jfxe.EventHandler[jfxsi.ZoomEvent] {
+      override def handle(event: jfxsi.ZoomEvent): Unit = handler(event)
+    }
   }
 
   /**
@@ -664,6 +830,11 @@ class Scene(override val delegate: jfxs.Scene = new jfxs.Scene(new jfxs.Group())
   def onZoomFinished_=(v: jfxe.EventHandler[jfxsi.ZoomEvent]) {
     onZoomFinished() = v
   }
+  def onZoomFinished_=(handler: jfxsi.ZoomEvent => Unit) {
+    onZoomFinished() = new jfxe.EventHandler[jfxsi.ZoomEvent] {
+      override def handle(event: jfxsi.ZoomEvent): Unit = handler(event)
+    }
+  }
 
   /**
    * Defines a function to be called when a Zoom gesture starts.
@@ -673,6 +844,11 @@ class Scene(override val delegate: jfxs.Scene = new jfxs.Scene(new jfxs.Group())
   def onZoomStarted = delegate.onZoomStartedProperty()
   def onZoomStarted_=(v: jfxe.EventHandler[jfxsi.ZoomEvent]) {
     onZoomStarted() = v
+  }
+  def onZoomStarted_=(handler: jfxsi.ZoomEvent => Unit) {
+    onZoomStarted() = new jfxe.EventHandler[jfxsi.ZoomEvent] {
+      override def handle(event: jfxsi.ZoomEvent): Unit = handler(event)
+    }
   }
 
   /**
@@ -684,6 +860,11 @@ class Scene(override val delegate: jfxs.Scene = new jfxs.Scene(new jfxs.Group())
   def onTouchMoved_=(v: jfxe.EventHandler[jfxsi.TouchEvent]) {
     onTouchMoved() = v
   }
+  def onTouchMoved_=(handler: jfxsi.TouchEvent => Unit) {
+    onTouchMoved() = new jfxe.EventHandler[jfxsi.TouchEvent] {
+      override def handle(event: jfxsi.TouchEvent): Unit = handler(event)
+    }
+  }
 
   /**
    * Defines a function to be called when user performs a Touch Pressed action.
@@ -693,6 +874,11 @@ class Scene(override val delegate: jfxs.Scene = new jfxs.Scene(new jfxs.Group())
   def onTouchPressed = delegate.onTouchPressedProperty()
   def onTouchPressed_=(v: jfxe.EventHandler[jfxsi.TouchEvent]) {
     onTouchPressed() = v
+  }
+  def onTouchPressed_=(handler: jfxsi.TouchEvent => Unit) {
+    onTouchPressed() = new jfxe.EventHandler[jfxsi.TouchEvent] {
+      override def handle(event: jfxsi.TouchEvent): Unit = handler(event)
+    }
   }
 
   /**
@@ -704,6 +890,11 @@ class Scene(override val delegate: jfxs.Scene = new jfxs.Scene(new jfxs.Group())
   def onTouchReleased_=(v: jfxe.EventHandler[jfxsi.TouchEvent]) {
     onTouchReleased() = v
   }
+  def onTouchReleased_=(handler: jfxsi.TouchEvent => Unit) {
+    onTouchReleased() = new jfxe.EventHandler[jfxsi.TouchEvent] {
+      override def handle(event: jfxsi.TouchEvent): Unit = handler(event)
+    }
+  }
 
   /**
    * Defines a function to be called when user performs a Touch Stationary action.
@@ -713,6 +904,11 @@ class Scene(override val delegate: jfxs.Scene = new jfxs.Scene(new jfxs.Group())
   def onTouchStationary = delegate.onTouchStationaryProperty()
   def onTouchStationary_=(v: jfxe.EventHandler[jfxsi.TouchEvent]) {
     onTouchStationary() = v
+  }
+  def onTouchStationary_=(handler: jfxsi.TouchEvent => Unit) {
+    onTouchStationary() = new jfxe.EventHandler[jfxsi.TouchEvent] {
+      override def handle(event: jfxsi.TouchEvent): Unit = handler(event)
+    }
   }
 
   /**

--- a/scalafx/src/main/scala/scalafx/scene/Scene.scala
+++ b/scalafx/src/main/scala/scalafx/scene/Scene.scala
@@ -34,9 +34,10 @@ import scalafx.Includes._
 import scalafx.beans.property.{ObjectProperty, ReadOnlyDoubleProperty, ReadOnlyObjectProperty}
 import scalafx.collections._
 import scalafx.delegate.SFXDelegate
+import scalafx.event.Event
 import scalafx.geometry.NodeOrientation
 import scalafx.scene.image.WritableImage
-import scalafx.scene.input.{Dragboard, Mnemonic, TransferMode}
+import scalafx.scene.input._
 import scalafx.scene.paint.Paint
 
 object Scene {
@@ -253,9 +254,10 @@ class Scene(override val delegate: jfxs.Scene = new jfxs.Scene(new jfxs.Group())
   def onContextMenuRequested_=(v: jfxe.EventHandler[_ >: jfxsi.ContextMenuEvent]) {
     onContextMenuRequested() = v
   }
-  def onContextMenuRequested_=[T >: jfxsi.ContextMenuEvent <: jfxe.Event](handler: T => Unit) {
-    onContextMenuRequested() = new jfxe.EventHandler[T] {
-      override def handle(event: T): Unit = handler(event)
+  def onContextMenuRequested_=[T >: ContextMenuEvent <: Event, U >: jfxsi.ContextMenuEvent <: jfxe.Event](handler: T => Unit)
+                                                                                                         (implicit jfx2sfx: U => T) {
+    onContextMenuRequested() = new jfxe.EventHandler[U] {
+      override def handle(event: U): Unit = handler(event)
     }
   }
 
@@ -266,9 +268,9 @@ class Scene(override val delegate: jfxs.Scene = new jfxs.Scene(new jfxs.Group())
   def onDragDetected_=(v: jfxe.EventHandler[_ >: jfxsi.MouseEvent]) {
     onDragDetected() = v
   }
-  def onDragDetected_=[T >: jfxsi.MouseEvent <: jfxe.Event](handler: T => Unit) {
-    onDragDetected() = new jfxe.EventHandler[T] {
-      override def handle(event: T): Unit = handler(event)
+  def onDragDetected_=[T >: MouseEvent <: Event, U >: jfxsi.MouseEvent <: jfxe.Event](handler: T => Unit)(implicit jfx2sfx: U => T) {
+    onDragDetected() = new jfxe.EventHandler[U] {
+      override def handle(event: U): Unit = handler(event)
     }
   }
 
@@ -280,9 +282,9 @@ class Scene(override val delegate: jfxs.Scene = new jfxs.Scene(new jfxs.Group())
   def onDragDone_=(v: jfxe.EventHandler[_ >: jfxsi.DragEvent]) {
     onDragDone() = v
   }
-  def onDragDone_=[T >: jfxsi.DragEvent <: jfxe.Event](handler: T => Unit) {
-    onDragDone() = new jfxe.EventHandler[T] {
-      override def handle(event: T): Unit = handler(event)
+  def onDragDone_=[T >: DragEvent <: Event, U >: jfxsi.DragEvent <: jfxe.Event](handler: T => Unit)(implicit jfx2sfx: U => T) {
+    onDragDone() = new jfxe.EventHandler[U] {
+      override def handle(event: U): Unit = handler(event)
     }
   }
 
@@ -293,9 +295,9 @@ class Scene(override val delegate: jfxs.Scene = new jfxs.Scene(new jfxs.Group())
   def onDragDropped_=(v: jfxe.EventHandler[_ >: jfxsi.DragEvent]) {
     onDragDropped() = v
   }
-  def onDragDropped_=[T >: jfxsi.DragEvent <: jfxe.Event](handler: T => Unit) {
-    onDragDropped() = new jfxe.EventHandler[T] {
-      override def handle(event: T): Unit = handler(event)
+  def onDragDropped_=[T >: DragEvent <: Event, U >: jfxsi.DragEvent <: jfxe.Event](handler: T => Unit)(implicit jfx2sfx: U => T) {
+    onDragDropped() = new jfxe.EventHandler[U] {
+      override def handle(event: U): Unit = handler(event)
     }
   }
 
@@ -306,9 +308,9 @@ class Scene(override val delegate: jfxs.Scene = new jfxs.Scene(new jfxs.Group())
   def onDragEntered_=(v: jfxe.EventHandler[_ >: jfxsi.DragEvent]) {
     onDragEntered() = v
   }
-  def onDragEntered_=[T >: jfxsi.DragEvent <: jfxe.Event](handler: T => Unit) {
-    onDragEntered() = new jfxe.EventHandler[T] {
-      override def handle(event: T): Unit = handler(event)
+  def onDragEntered_=[T >: DragEvent <: Event, U >: jfxsi.DragEvent <: jfxe.Event](handler: T => Unit)(implicit jfx2sfx: U => T) {
+    onDragEntered() = new jfxe.EventHandler[U] {
+      override def handle(event: U): Unit = handler(event)
     }
   }
 
@@ -319,9 +321,9 @@ class Scene(override val delegate: jfxs.Scene = new jfxs.Scene(new jfxs.Group())
   def onDragExited_=(v: jfxe.EventHandler[_ >: jfxsi.DragEvent]) {
     onDragExited() = v
   }
-  def onDragExited_=[T >: jfxsi.DragEvent <: jfxe.Event](handler: T => Unit) {
-    onDragExited() = new jfxe.EventHandler[T] {
-      override def handle(event: T): Unit = handler(event)
+  def onDragExited_=[T >: DragEvent <: Event, U >: jfxsi.DragEvent <: jfxe.Event](handler: T => Unit)(implicit jfx2sfx: U => T) {
+    onDragExited() = new jfxe.EventHandler[U] {
+      override def handle(event: U): Unit = handler(event)
     }
   }
 
@@ -332,9 +334,9 @@ class Scene(override val delegate: jfxs.Scene = new jfxs.Scene(new jfxs.Group())
   def onDragOver_=(v: jfxe.EventHandler[_ >: jfxsi.DragEvent]) {
     onDragOver() = v
   }
-  def onDragOver_=[T >: jfxsi.DragEvent <: jfxe.Event](handler: T => Unit) {
-    onDragOver() = new jfxe.EventHandler[T] {
-      override def handle(event: T): Unit = handler(event)
+  def onDragOver_=[T >: DragEvent <: Event, U >: jfxsi.DragEvent <: jfxe.Event](handler: T => Unit)(implicit jfx2sfx: U => T) {
+    onDragOver() = new jfxe.EventHandler[U] {
+      override def handle(event: U): Unit = handler(event)
     }
   }
 
@@ -345,9 +347,10 @@ class Scene(override val delegate: jfxs.Scene = new jfxs.Scene(new jfxs.Group())
   def onInputMethodTextChanged_=(v: jfxe.EventHandler[_ >: jfxsi.InputMethodEvent]) {
     onInputMethodTextChanged() = v
   }
-  def onInputMethodTextChanged_=[T >: jfxsi.InputMethodEvent <: jfxe.Event](handler: T => Unit) {
-    onInputMethodTextChanged() = new jfxe.EventHandler[T] {
-      override def handle(event: T): Unit = handler(event)
+  def onInputMethodTextChanged_=[T >: InputMethodEvent <: Event, U >: jfxsi.InputMethodEvent <: jfxe.Event](handler: T => Unit)
+                                                                                                           (implicit jfx2sfx: U => T) {
+    onInputMethodTextChanged() = new jfxe.EventHandler[U] {
+      override def handle(event: U): Unit = handler(event)
     }
   }
 
@@ -358,9 +361,9 @@ class Scene(override val delegate: jfxs.Scene = new jfxs.Scene(new jfxs.Group())
   def onKeyPressed_=(v: jfxe.EventHandler[_ >: jfxsi.KeyEvent]) {
     onKeyPressed() = v
   }
-  def onKeyPressed_=[T >: jfxsi.KeyEvent <: jfxe.Event](handler: T => Unit) {
-    onKeyPressed() = new jfxe.EventHandler[T] {
-      override def handle(event: T): Unit = handler(event)
+  def onKeyPressed_=[T >: KeyEvent <: Event, U >: jfxsi.KeyEvent <: jfxe.Event](handler: T => Unit)(implicit jfx2sfx: U => T) {
+    onKeyPressed() = new jfxe.EventHandler[U] {
+      override def handle(event: U): Unit = handler(event)
     }
   }
 
@@ -371,9 +374,9 @@ class Scene(override val delegate: jfxs.Scene = new jfxs.Scene(new jfxs.Group())
   def onKeyReleased_=(v: jfxe.EventHandler[_ >: jfxsi.KeyEvent]) {
     onKeyReleased() = v
   }
-  def onKeyReleased_=[T >: jfxsi.KeyEvent <: jfxe.Event](handler: T => Unit) {
-    onKeyReleased() = new jfxe.EventHandler[T] {
-      override def handle(event: T): Unit = handler(event)
+  def onKeyReleased_=[T >: KeyEvent <: Event, U >: jfxsi.KeyEvent <: jfxe.Event](handler: T => Unit)(implicit jfx2sfx: U => T) {
+    onKeyReleased() = new jfxe.EventHandler[U] {
+      override def handle(event: U): Unit = handler(event)
     }
   }
 
@@ -384,9 +387,9 @@ class Scene(override val delegate: jfxs.Scene = new jfxs.Scene(new jfxs.Group())
   def onKeyTyped_=(v: jfxe.EventHandler[_ >: jfxsi.KeyEvent]) {
     onKeyTyped() = v
   }
-  def onKeyTyped_=[T >: jfxsi.KeyEvent <: jfxe.Event](handler: T => Unit) {
-    onKeyTyped() = new jfxe.EventHandler[T] {
-      override def handle(event: T): Unit = handler(event)
+  def onKeyTyped_=[T >: KeyEvent <: Event, U >: jfxsi.KeyEvent <: jfxe.Event](handler: T => Unit)(implicit jfx2sfx: U => T) {
+    onKeyTyped() = new jfxe.EventHandler[U] {
+      override def handle(event: U): Unit = handler(event)
     }
   }
 
@@ -397,9 +400,9 @@ class Scene(override val delegate: jfxs.Scene = new jfxs.Scene(new jfxs.Group())
   def onMouseClicked_=(v: jfxe.EventHandler[_ >: jfxsi.MouseEvent]) {
     onMouseClicked() = v
   }
-  def onMouseClicked_=[T >: jfxsi.MouseEvent <: jfxe.Event](handler: T => Unit) {
-    onMouseClicked() = new jfxe.EventHandler[T] {
-      override def handle(event: T): Unit = handler(event)
+  def onMouseClicked_=[T >: MouseEvent <: Event, U >: jfxsi.MouseEvent <: jfxe.Event](handler: T => Unit)(implicit jfx2sfx: U => T) {
+    onMouseClicked() = new jfxe.EventHandler[U] {
+      override def handle(event: U): Unit = handler(event)
     }
   }
 
@@ -410,9 +413,9 @@ class Scene(override val delegate: jfxs.Scene = new jfxs.Scene(new jfxs.Group())
   def onMouseDragged_=(v: jfxe.EventHandler[_ >: jfxsi.MouseEvent]) {
     onMouseDragged() = v
   }
-  def onMouseDragged_=[T >: jfxsi.MouseEvent <: jfxe.Event](handler: T => Unit) {
-    onMouseDragged() = new jfxe.EventHandler[T] {
-      override def handle(event: T): Unit = handler(event)
+  def onMouseDragged_=[T >: MouseEvent <: Event, U >: jfxsi.MouseEvent <: jfxe.Event](handler: T => Unit)(implicit jfx2sfx: U => T) {
+    onMouseDragged() = new jfxe.EventHandler[U] {
+      override def handle(event: U): Unit = handler(event)
     }
   }
 
@@ -423,9 +426,10 @@ class Scene(override val delegate: jfxs.Scene = new jfxs.Scene(new jfxs.Group())
   def onMouseDragEntered_=(v: jfxe.EventHandler[_ >: jfxsi.MouseDragEvent]) {
     onMouseDragEntered() = v
   }
-  def onMouseDragEntered_=[T >: jfxsi.MouseDragEvent <: jfxe.Event](handler: T => Unit) {
-    onMouseDragEntered() = new jfxe.EventHandler[T] {
-      override def handle(event: T): Unit = handler(event)
+  def onMouseDragEntered_=[T >: MouseDragEvent <: Event, U >: jfxsi.MouseDragEvent <: jfxe.Event](handler: T => Unit)
+                                                                                                 (implicit jfx2sfx: U => T) {
+    onMouseDragEntered() = new jfxe.EventHandler[U] {
+      override def handle(event: U): Unit = handler(event)
     }
   }
 
@@ -436,9 +440,10 @@ class Scene(override val delegate: jfxs.Scene = new jfxs.Scene(new jfxs.Group())
   def onMouseDragExited_=(v: jfxe.EventHandler[_ >: jfxsi.MouseDragEvent]) {
     onMouseDragExited() = v
   }
-  def onMouseDragExited_=[T >: jfxsi.MouseDragEvent <: jfxe.Event](handler: T => Unit) {
-    onMouseDragExited() = new jfxe.EventHandler[T] {
-      override def handle(event: T): Unit = handler(event)
+  def onMouseDragExited_=[T >: MouseDragEvent <: Event, U >: jfxsi.MouseDragEvent <: jfxe.Event](handler: T => Unit)
+                                                                                                (implicit jfx2sfx: U => T) {
+    onMouseDragExited() = new jfxe.EventHandler[U] {
+      override def handle(event: U): Unit = handler(event)
     }
   }
 
@@ -449,9 +454,10 @@ class Scene(override val delegate: jfxs.Scene = new jfxs.Scene(new jfxs.Group())
   def onMouseDragOver_=(v: jfxe.EventHandler[_ >: jfxsi.MouseDragEvent]) {
     onMouseDragOver() = v
   }
-  def onMouseDragOver_=[T >: jfxsi.MouseDragEvent <: jfxe.Event](handler: T => Unit) {
-    onMouseDragOver() = new jfxe.EventHandler[T] {
-      override def handle(event: T): Unit = handler(event)
+  def onMouseDragOver_=[T >: MouseDragEvent <: Event, U >: jfxsi.MouseDragEvent <: jfxe.Event](handler: T => Unit)
+                                                                                              (implicit jfx2sfx: U => T) {
+    onMouseDragOver() = new jfxe.EventHandler[U] {
+      override def handle(event: U): Unit = handler(event)
     }
   }
 
@@ -462,9 +468,10 @@ class Scene(override val delegate: jfxs.Scene = new jfxs.Scene(new jfxs.Group())
   def onMouseDragReleased_=(v: jfxe.EventHandler[_ >: jfxsi.MouseDragEvent]) {
     onMouseDragReleased() = v
   }
-  def onMouseDragReleased_=[T >: jfxsi.MouseDragEvent <: jfxe.Event](handler: T => Unit) {
-    onMouseDragReleased() = new jfxe.EventHandler[T] {
-      override def handle(event: T): Unit = handler(event)
+  def onMouseDragReleased_=[T >: MouseDragEvent <: Event, U >: jfxsi.MouseDragEvent <: jfxe.Event](handler: T => Unit)
+                                                                                                  (implicit jfx2sfx: U => T) {
+    onMouseDragReleased() = new jfxe.EventHandler[U] {
+      override def handle(event: U): Unit = handler(event)
     }
   }
 
@@ -475,9 +482,9 @@ class Scene(override val delegate: jfxs.Scene = new jfxs.Scene(new jfxs.Group())
   def onMouseEntered_=(v: jfxe.EventHandler[_ >: jfxsi.MouseEvent]) {
     onMouseEntered() = v
   }
-  def onMouseEntered_=[T >: jfxsi.MouseEvent <: jfxe.Event](handler: T => Unit) {
-    onMouseEntered() = new jfxe.EventHandler[T] {
-      override def handle(event: T): Unit = handler(event)
+  def onMouseEntered_=[T >: MouseEvent <: Event, U >: jfxsi.MouseEvent <: jfxe.Event](handler: T => Unit)(implicit jfx2sfx: U => T) {
+    onMouseEntered() = new jfxe.EventHandler[U] {
+      override def handle(event: U): Unit = handler(event)
     }
   }
 
@@ -488,9 +495,9 @@ class Scene(override val delegate: jfxs.Scene = new jfxs.Scene(new jfxs.Group())
   def onMouseExited_=(v: jfxe.EventHandler[_ >: jfxsi.MouseEvent]) {
     onMouseExited() = v
   }
-  def onMouseExited_=[T >: jfxsi.MouseEvent <: jfxe.Event](handler: T => Unit) {
-    onMouseExited() = new jfxe.EventHandler[T] {
-      override def handle(event: T): Unit = handler(event)
+  def onMouseExited_=[T >: MouseEvent <: Event, U >: jfxsi.MouseEvent <: jfxe.Event](handler: T => Unit)(implicit jfx2sfx: U => T) {
+    onMouseExited() = new jfxe.EventHandler[U] {
+      override def handle(event: U): Unit = handler(event)
     }
   }
 
@@ -501,9 +508,9 @@ class Scene(override val delegate: jfxs.Scene = new jfxs.Scene(new jfxs.Group())
   def onMouseMoved_=(v: jfxe.EventHandler[_ >: jfxsi.MouseEvent]) {
     onMouseMoved() = v
   }
-  def onMouseMoved_=[T >: jfxsi.MouseEvent <: jfxe.Event](handler: T => Unit) {
-    onMouseMoved() = new jfxe.EventHandler[T] {
-      override def handle(event: T): Unit = handler(event)
+  def onMouseMoved_=[T >: MouseEvent <: Event, U >: jfxsi.MouseEvent <: jfxe.Event](handler: T => Unit)(implicit jfx2sfx: U => T) {
+    onMouseMoved() = new jfxe.EventHandler[U] {
+      override def handle(event: U): Unit = handler(event)
     }
   }
 
@@ -515,9 +522,9 @@ class Scene(override val delegate: jfxs.Scene = new jfxs.Scene(new jfxs.Group())
   def onMousePressed_=(v: jfxe.EventHandler[_ >: jfxsi.MouseEvent]) {
     onMousePressed() = v
   }
-  def onMousePressed_=[T >: jfxsi.MouseEvent <: jfxe.Event](handler: T => Unit) {
-    onMousePressed() = new jfxe.EventHandler[T] {
-      override def handle(event: T): Unit = handler(event)
+  def onMousePressed_=[T >: MouseEvent <: Event, U >: jfxsi.MouseEvent <: jfxe.Event](handler: T => Unit)(implicit jfx2sfx: U => T) {
+    onMousePressed() = new jfxe.EventHandler[U] {
+      override def handle(event: U): Unit = handler(event)
     }
   }
 
@@ -528,9 +535,9 @@ class Scene(override val delegate: jfxs.Scene = new jfxs.Scene(new jfxs.Group())
   def onMouseReleased_=(v: jfxe.EventHandler[_ >: jfxsi.MouseEvent]) {
     onMouseReleased() = v
   }
-  def onMouseReleased_=[T >: jfxsi.MouseEvent <: jfxe.Event](handler: T => Unit) {
-    onMouseReleased() = new jfxe.EventHandler[T] {
-      override def handle(event: T): Unit = handler(event)
+  def onMouseReleased_=[T >: MouseEvent <: Event, U >: jfxsi.MouseEvent <: jfxe.Event](handler: T => Unit)(implicit jfx2sfx: U => T) {
+    onMouseReleased() = new jfxe.EventHandler[U] {
+      override def handle(event: U): Unit = handler(event)
     }
   }
 
@@ -541,9 +548,9 @@ class Scene(override val delegate: jfxs.Scene = new jfxs.Scene(new jfxs.Group())
   def onScroll_=(v: jfxe.EventHandler[_ >: jfxsi.ScrollEvent]) {
     onScroll() = v
   }
-  def onScroll_=[T >: jfxsi.ScrollEvent <: jfxe.Event](handler: T => Unit) {
-    onScroll() = new jfxe.EventHandler[T] {
-      override def handle(event: T): Unit = handler(event)
+  def onScroll_=[T >: ScrollEvent <: Event, U >: jfxsi.ScrollEvent <: jfxe.Event](handler: T => Unit)(implicit jfx2sfx: U => T) {
+    onScroll() = new jfxe.EventHandler[U] {
+      override def handle(event: U): Unit = handler(event)
     }
   }
 
@@ -677,12 +684,13 @@ class Scene(override val delegate: jfxs.Scene = new jfxs.Scene(new jfxs.Group())
    * @since 2.2
    */
   def onRotate = delegate.onRotateProperty
-  def onRotate_=(v: jfxe.EventHandler[jfxsi.RotateEvent]) {
+  def onRotate_=(v: jfxe.EventHandler[_ >:jfxsi.RotateEvent]) {
     onRotate() = v
   }
-  def onRotate_=(handler: jfxsi.RotateEvent => Unit) {
-    onRotate() = new jfxe.EventHandler[jfxsi.RotateEvent] {
-      override def handle(event: jfxsi.RotateEvent): Unit = handler(event)
+  def onRotate_=[T >: RotateEvent <: Event, U >: jfxsi.RotateEvent <: jfxe.Event](handler: T => Unit)
+                                                                                 (implicit jfx2sfx: U => T) {
+    onRotate() = new jfxe.EventHandler[U] {
+      override def handle(event: U): Unit = handler(event)
     }
   }
 
@@ -692,12 +700,13 @@ class Scene(override val delegate: jfxs.Scene = new jfxs.Scene(new jfxs.Group())
    * @since 2.2
    */
   def onRotationFinished = delegate.onRotationFinishedProperty()
-  def onRotationFinished_=(v: jfxe.EventHandler[jfxsi.RotateEvent]) {
+  def onRotationFinished_=(v: jfxe.EventHandler[_ >: jfxsi.RotateEvent]) {
     onRotationFinished() = v
   }
-  def onRotationFinished_=(handler: jfxsi.RotateEvent => Unit) {
-    onRotationFinished() = new jfxe.EventHandler[jfxsi.RotateEvent] {
-      override def handle(event: jfxsi.RotateEvent): Unit = handler(event)
+  def onRotationFinished_=[T >: RotateEvent <: Event, U >: jfxsi.RotateEvent <: jfxe.Event](handler: T => Unit)
+                                                                                           (implicit jfx2sfx: U => T) {
+    onRotationFinished() = new jfxe.EventHandler[U] {
+      override def handle(event: U): Unit = handler(event)
     }
   }
 
@@ -707,12 +716,13 @@ class Scene(override val delegate: jfxs.Scene = new jfxs.Scene(new jfxs.Group())
    * @since 2.2
    */
   def onRotationStarted = delegate.onRotationFinishedProperty()
-  def onRotationStarted_=(v: jfxe.EventHandler[jfxsi.RotateEvent]) {
+  def onRotationStarted_=(v: jfxe.EventHandler[_ >: jfxsi.RotateEvent]) {
     onRotationStarted() = v
   }
-  def onRotationStarted_=(handler: jfxsi.RotateEvent => Unit) {
-    onRotationStarted() = new jfxe.EventHandler[jfxsi.RotateEvent] {
-      override def handle(event: jfxsi.RotateEvent): Unit = handler(event)
+  def onRotationStarted_=[T >: RotateEvent <: Event, U >: jfxsi.RotateEvent <: jfxe.Event](handler: T => Unit)
+                                                                                          (implicit jfx2sfx: U => T) {
+    onRotationStarted() = new jfxe.EventHandler[U] {
+      override def handle(event: U): Unit = handler(event)
     }
   }
 
@@ -722,12 +732,13 @@ class Scene(override val delegate: jfxs.Scene = new jfxs.Scene(new jfxs.Group())
    * @since 2.2
    */
   def onScrollFinished = delegate.onScrollFinishedProperty()
-  def onScrollFinished_=(v: jfxe.EventHandler[jfxsi.ScrollEvent]) {
+  def onScrollFinished_=(v: jfxe.EventHandler[_ >: jfxsi.ScrollEvent]) {
     onScrollFinished() = v
   }
-  def onScrollFinished_=(handler: jfxsi.ScrollEvent => Unit) {
-    onScrollFinished() = new jfxe.EventHandler[jfxsi.ScrollEvent] {
-      override def handle(event: jfxsi.ScrollEvent): Unit = handler(event)
+  def onScrollFinished_=[T >: ScrollEvent <: Event, U >: jfxsi.ScrollEvent <: jfxe.Event](handler: T => Unit)
+                                                                                         (implicit jfx2sfx: U => T) {
+    onScrollFinished() = new jfxe.EventHandler[U] {
+      override def handle(event: U): Unit = handler(event)
     }
   }
 
@@ -737,12 +748,13 @@ class Scene(override val delegate: jfxs.Scene = new jfxs.Scene(new jfxs.Group())
    * @since 2.2
    */
   def onScrollStarted = delegate.onScrollStartedProperty()
-  def onScrollStarted_=(v: jfxe.EventHandler[jfxsi.ScrollEvent]) {
+  def onScrollStarted_=(v: jfxe.EventHandler[_ >: jfxsi.ScrollEvent]) {
     onScrollStarted() = v
   }
-  def onScrollStarted_=(handler: jfxsi.ScrollEvent => Unit) {
-    onScrollStarted() = new jfxe.EventHandler[jfxsi.ScrollEvent] {
-      override def handle(event: jfxsi.ScrollEvent): Unit = handler(event)
+  def onScrollStarted_=[T >: ScrollEvent <: Event, U >: jfxsi.ScrollEvent <: jfxe.Event](handler: T => Unit)
+                                                                                        (implicit jfx2sfx: U => T) {
+    onScrollStarted() = new jfxe.EventHandler[U] {
+      override def handle(event: U): Unit = handler(event)
     }
   }
 
@@ -752,12 +764,13 @@ class Scene(override val delegate: jfxs.Scene = new jfxs.Scene(new jfxs.Group())
    * @since 2.2
    */
   def onSwipeDown = delegate.onSwipeDownProperty()
-  def onSwipeDown_=(v: jfxe.EventHandler[jfxsi.SwipeEvent]) {
+  def onSwipeDown_=(v: jfxe.EventHandler[_ >: jfxsi.SwipeEvent]) {
     onSwipeDown() = v
   }
-  def onSwipeDown_=(handler: jfxsi.SwipeEvent => Unit) {
-    onSwipeDown() = new jfxe.EventHandler[jfxsi.SwipeEvent] {
-      override def handle(event: jfxsi.SwipeEvent): Unit = handler(event)
+  def onSwipeDown_=[T >: SwipeEvent <: Event, U >: jfxsi.SwipeEvent <: jfxe.Event](handler: T => Unit)
+                                                                                    (implicit jfx2sfx: U => T) {
+    onSwipeDown() = new jfxe.EventHandler[U] {
+      override def handle(event: U): Unit = handler(event)
     }
   }
 
@@ -767,12 +780,13 @@ class Scene(override val delegate: jfxs.Scene = new jfxs.Scene(new jfxs.Group())
    * @since 2.2
    */
   def onSwipeLeft = delegate.onSwipeLeftProperty()
-  def onSwipeLeft_=(v: jfxe.EventHandler[jfxsi.SwipeEvent]) {
+  def onSwipeLeft_=(v: jfxe.EventHandler[_ >: jfxsi.SwipeEvent]) {
     onSwipeLeft() = v
   }
-  def onSwipeLeft_=(handler: jfxsi.SwipeEvent => Unit) {
-    onSwipeLeft() = new jfxe.EventHandler[jfxsi.SwipeEvent] {
-      override def handle(event: jfxsi.SwipeEvent): Unit = handler(event)
+  def onSwipeLeft_=[T >: SwipeEvent <: Event, U >: jfxsi.SwipeEvent <: jfxe.Event](handler: T => Unit)
+                                                                                  (implicit jfx2sfx: U => T) {
+    onSwipeLeft() = new jfxe.EventHandler[U] {
+      override def handle(event: U): Unit = handler(event)
     }
   }
 
@@ -782,12 +796,13 @@ class Scene(override val delegate: jfxs.Scene = new jfxs.Scene(new jfxs.Group())
    * @since 2.2
    */
   def onSwipeUp = delegate.onSwipeUpProperty()
-  def onSwipeUp_=(v: jfxe.EventHandler[jfxsi.SwipeEvent]) {
+  def onSwipeUp_=(v: jfxe.EventHandler[_ >: jfxsi.SwipeEvent]) {
     onSwipeUp() = v
   }
-  def onSwipeUp_=(handler: jfxsi.SwipeEvent => Unit) {
-    onSwipeUp() = new jfxe.EventHandler[jfxsi.SwipeEvent] {
-      override def handle(event: jfxsi.SwipeEvent): Unit = handler(event)
+  def onSwipeUp_=[T >: SwipeEvent <: Event, U >: jfxsi.SwipeEvent <: jfxe.Event](handler: T => Unit)
+                                                                                (implicit jfx2sfx: U => T) {
+    onSwipeUp() = new jfxe.EventHandler[U] {
+      override def handle(event: U): Unit = handler(event)
     }
   }
 
@@ -797,12 +812,13 @@ class Scene(override val delegate: jfxs.Scene = new jfxs.Scene(new jfxs.Group())
    * @since 2.2
    */
   def onSwipeRight = delegate.onSwipeRightProperty()
-  def onSwipeRight_=(v: jfxe.EventHandler[jfxsi.SwipeEvent]) {
+  def onSwipeRight_=(v: jfxe.EventHandler[_ >: jfxsi.SwipeEvent]) {
     onSwipeRight() = v
   }
-  def onSwipeRight_=(handler: jfxsi.SwipeEvent => Unit) {
-    onSwipeRight() = new jfxe.EventHandler[jfxsi.SwipeEvent] {
-      override def handle(event: jfxsi.SwipeEvent): Unit = handler(event)
+  def onSwipeRight_=[T >: SwipeEvent <: Event, U >: jfxsi.SwipeEvent <: jfxe.Event](handler: T => Unit)
+                                                                                   (implicit jfx2sfx: U => T) {
+    onSwipeRight() = new jfxe.EventHandler[U] {
+      override def handle(event: U): Unit = handler(event)
     }
   }
 
@@ -812,12 +828,13 @@ class Scene(override val delegate: jfxs.Scene = new jfxs.Scene(new jfxs.Group())
    * @since 2.2
    */
   def onZoom = delegate.onZoomProperty()
-  def onZoom_=(v: jfxe.EventHandler[jfxsi.ZoomEvent]) {
+  def onZoom_=(v: jfxe.EventHandler[_ >: jfxsi.ZoomEvent]) {
     onZoom() = v
   }
-  def onZoom_=(handler: jfxsi.ZoomEvent => Unit) {
-    onZoom() = new jfxe.EventHandler[jfxsi.ZoomEvent] {
-      override def handle(event: jfxsi.ZoomEvent): Unit = handler(event)
+  def onZoom_=[T >: ZoomEvent <: Event, U >: jfxsi.ZoomEvent <: jfxe.Event](handler: T => Unit)
+                                                                             (implicit jfx2sfx: U => T) {
+    onZoom() = new jfxe.EventHandler[U] {
+      override def handle(event: U): Unit = handler(event)
     }
   }
 
@@ -830,9 +847,10 @@ class Scene(override val delegate: jfxs.Scene = new jfxs.Scene(new jfxs.Group())
   def onZoomFinished_=(v: jfxe.EventHandler[jfxsi.ZoomEvent]) {
     onZoomFinished() = v
   }
-  def onZoomFinished_=(handler: jfxsi.ZoomEvent => Unit) {
-    onZoomFinished() = new jfxe.EventHandler[jfxsi.ZoomEvent] {
-      override def handle(event: jfxsi.ZoomEvent): Unit = handler(event)
+  def onZoomFinished_=[T >: ZoomEvent <: Event, U >: jfxsi.ZoomEvent <: jfxe.Event](handler: T => Unit)
+                                                                                   (implicit jfx2sfx: U => T) {
+    onZoomFinished() = new jfxe.EventHandler[U] {
+      override def handle(event: U): Unit = handler(event)
     }
   }
 
@@ -845,9 +863,10 @@ class Scene(override val delegate: jfxs.Scene = new jfxs.Scene(new jfxs.Group())
   def onZoomStarted_=(v: jfxe.EventHandler[jfxsi.ZoomEvent]) {
     onZoomStarted() = v
   }
-  def onZoomStarted_=(handler: jfxsi.ZoomEvent => Unit) {
-    onZoomStarted() = new jfxe.EventHandler[jfxsi.ZoomEvent] {
-      override def handle(event: jfxsi.ZoomEvent): Unit = handler(event)
+  def onZoomStarted_=[T >: ZoomEvent <: Event, U >: jfxsi.ZoomEvent <: jfxe.Event](handler: T => Unit)
+                                                                                  (implicit jfx2sfx: U => T) {
+    onZoomStarted() = new jfxe.EventHandler[U] {
+      override def handle(event: U): Unit = handler(event)
     }
   }
 
@@ -857,12 +876,13 @@ class Scene(override val delegate: jfxs.Scene = new jfxs.Scene(new jfxs.Group())
    * @since 2.2
    */
   def onTouchMoved = delegate.onTouchMovedProperty()
-  def onTouchMoved_=(v: jfxe.EventHandler[jfxsi.TouchEvent]) {
+  def onTouchMoved_=(v: jfxe.EventHandler[_ >: jfxsi.TouchEvent]) {
     onTouchMoved() = v
   }
-  def onTouchMoved_=(handler: jfxsi.TouchEvent => Unit) {
-    onTouchMoved() = new jfxe.EventHandler[jfxsi.TouchEvent] {
-      override def handle(event: jfxsi.TouchEvent): Unit = handler(event)
+  def onTouchMoved_=[T >: TouchEvent <: Event, U >: jfxsi.TouchEvent <: jfxe.Event](handler: T => Unit)
+                                                                                 (implicit jfx2sfx: U => T) {
+    onTouchMoved() = new jfxe.EventHandler[U] {
+      override def handle(event: U): Unit = handler(event)
     }
   }
 
@@ -872,12 +892,13 @@ class Scene(override val delegate: jfxs.Scene = new jfxs.Scene(new jfxs.Group())
    * @since 2.2
    */
   def onTouchPressed = delegate.onTouchPressedProperty()
-  def onTouchPressed_=(v: jfxe.EventHandler[jfxsi.TouchEvent]) {
+  def onTouchPressed_=(v: jfxe.EventHandler[_ >: jfxsi.TouchEvent]) {
     onTouchPressed() = v
   }
-  def onTouchPressed_=(handler: jfxsi.TouchEvent => Unit) {
-    onTouchPressed() = new jfxe.EventHandler[jfxsi.TouchEvent] {
-      override def handle(event: jfxsi.TouchEvent): Unit = handler(event)
+  def onTouchPressed_=[T >: TouchEvent <: Event, U >: jfxsi.TouchEvent <: jfxe.Event](handler: T => Unit)
+                                                                                   (implicit jfx2sfx: U => T) {
+    onTouchPressed() = new jfxe.EventHandler[U] {
+      override def handle(event: U): Unit = handler(event)
     }
   }
 
@@ -887,12 +908,13 @@ class Scene(override val delegate: jfxs.Scene = new jfxs.Scene(new jfxs.Group())
    * @since 2.2
    */
   def onTouchReleased = delegate.onTouchReleasedProperty()
-  def onTouchReleased_=(v: jfxe.EventHandler[jfxsi.TouchEvent]) {
+  def onTouchReleased_=(v: jfxe.EventHandler[_ >: jfxsi.TouchEvent]) {
     onTouchReleased() = v
   }
-  def onTouchReleased_=(handler: jfxsi.TouchEvent => Unit) {
-    onTouchReleased() = new jfxe.EventHandler[jfxsi.TouchEvent] {
-      override def handle(event: jfxsi.TouchEvent): Unit = handler(event)
+  def onTouchReleased_=[T >: TouchEvent <: Event, U >: jfxsi.TouchEvent <: jfxe.Event](handler: T => Unit)
+                                                                                      (implicit jfx2sfx: U => T) {
+    onTouchReleased() = new jfxe.EventHandler[U] {
+      override def handle(event: U): Unit = handler(event)
     }
   }
 
@@ -902,12 +924,13 @@ class Scene(override val delegate: jfxs.Scene = new jfxs.Scene(new jfxs.Group())
    * @since 2.2
    */
   def onTouchStationary = delegate.onTouchStationaryProperty()
-  def onTouchStationary_=(v: jfxe.EventHandler[jfxsi.TouchEvent]) {
+  def onTouchStationary_=(v: jfxe.EventHandler[_ >: jfxsi.TouchEvent]) {
     onTouchStationary() = v
   }
-  def onTouchStationary_=(handler: jfxsi.TouchEvent => Unit) {
-    onTouchStationary() = new jfxe.EventHandler[jfxsi.TouchEvent] {
-      override def handle(event: jfxsi.TouchEvent): Unit = handler(event)
+  def onTouchStationary_=[T >: TouchEvent <: Event, U >: jfxsi.TouchEvent <: jfxe.Event](handler: T => Unit)
+                                                                                        (implicit jfx2sfx: U => T) {
+    onTouchStationary() = new jfxe.EventHandler[U] {
+      override def handle(event: U): Unit = handler(event)
     }
   }
 

--- a/scalafx/src/main/scala/scalafx/scene/control/ButtonBase.scala
+++ b/scalafx/src/main/scala/scalafx/scene/control/ButtonBase.scala
@@ -56,6 +56,11 @@ abstract class ButtonBase(override val delegate: jfxsc.ButtonBase)
   def onAction_=(implicit aeh: jfxe.EventHandler[jfxe.ActionEvent]) {
     onAction() = aeh
   }
+  def onAction_=(handler: jfxe.ActionEvent => Unit): Unit = {
+    onAction() = new jfxe.EventHandler[jfxe.ActionEvent] {
+      override def handle(event: jfxe.ActionEvent): Unit = handler(event)
+    }
+  }
 
   /**
    * Arms the button.

--- a/scalafx/src/main/scala/scalafx/scene/control/ButtonBase.scala
+++ b/scalafx/src/main/scala/scalafx/scene/control/ButtonBase.scala
@@ -33,6 +33,7 @@ import scala.language.implicitConversions
 import scalafx.Includes._
 import scalafx.beans.property.ReadOnlyBooleanProperty
 import scalafx.delegate.{FireDelegate, SFXDelegate}
+import scalafx.event.ActionEvent
 import scalafx.scene.input.MouseEvent
 
 object ButtonBase {
@@ -56,7 +57,7 @@ abstract class ButtonBase(override val delegate: jfxsc.ButtonBase)
   def onAction_=(implicit aeh: jfxe.EventHandler[jfxe.ActionEvent]) {
     onAction() = aeh
   }
-  def onAction_=(handler: jfxe.ActionEvent => Unit): Unit = {
+  def onAction_=(handler: ActionEvent => Unit): Unit = {
     onAction() = new jfxe.EventHandler[jfxe.ActionEvent] {
       override def handle(event: jfxe.ActionEvent): Unit = handler(event)
     }

--- a/scalafx/src/main/scala/scalafx/scene/control/ComboBoxBase.scala
+++ b/scalafx/src/main/scala/scalafx/scene/control/ComboBoxBase.scala
@@ -33,6 +33,7 @@ import scala.language.implicitConversions
 import scalafx.Includes._
 import scalafx.beans.property.{BooleanProperty, ObjectProperty, ReadOnlyBooleanProperty, StringProperty}
 import scalafx.delegate.SFXDelegate
+import scalafx.event.{Event, ActionEvent}
 
 object ComboBoxBase {
   implicit def sfxComboBoxBase2jfx[T](cb: ComboBoxBase[T]): jfxsc.ComboBoxBase[T] = if (cb != null) cb.delegate else null
@@ -84,7 +85,7 @@ abstract class ComboBoxBase[T](override val delegate: jfxsc.ComboBoxBase[T]) ext
   def onAction_=(v: jfxe.EventHandler[jfxe.ActionEvent]) {
     onAction() = v
   }
-  def onAction_=(handler: jfxe.ActionEvent => Unit) {
+  def onAction_=(handler: ActionEvent => Unit) {
     onAction() = new jfxe.EventHandler[jfxe.ActionEvent] {
       override def handle(event: jfxe.ActionEvent): Unit = handler(event)
     }
@@ -126,7 +127,7 @@ abstract class ComboBoxBase[T](override val delegate: jfxsc.ComboBoxBase[T]) ext
   def onHidden_=(eventHandler: jfxe.EventHandler[jfxe.Event]) {
     onHidden() = eventHandler
   }
-  def onHidden_=(handler: jfxe.Event => Unit) {
+  def onHidden_=(handler: Event => Unit) {
     onHidden() = new jfxe.EventHandler[jfxe.Event] {
       override def handle(event: jfxe.Event): Unit = handler(event)
     }
@@ -140,7 +141,7 @@ abstract class ComboBoxBase[T](override val delegate: jfxsc.ComboBoxBase[T]) ext
   def onHiding_=(eventHandler: jfxe.EventHandler[jfxe.Event]) {
     onHiding() = eventHandler
   }
-  def onHiding_=(handler: jfxe.Event => Unit) {
+  def onHiding_=(handler: Event => Unit) {
     onHiding() = new jfxe.EventHandler[jfxe.Event] {
       override def handle(event: jfxe.Event): Unit = handler(event)
     }
@@ -154,7 +155,7 @@ abstract class ComboBoxBase[T](override val delegate: jfxsc.ComboBoxBase[T]) ext
   def onShowing_=(eventHandler: jfxe.EventHandler[jfxe.Event]) {
     onShowing() = eventHandler
   }
-  def onShowing_=(handler: jfxe.Event => Unit) {
+  def onShowing_=(handler: Event => Unit) {
     onShowing() = new jfxe.EventHandler[jfxe.Event] {
       override def handle(event: jfxe.Event): Unit = handler(event)
     }
@@ -168,7 +169,7 @@ abstract class ComboBoxBase[T](override val delegate: jfxsc.ComboBoxBase[T]) ext
   def onShown_=(eventHandler: jfxe.EventHandler[jfxe.Event]) {
     onShown() = eventHandler
   }
-  def onShown_=(handler: jfxe.Event => Unit) {
+  def onShown_=(handler: Event => Unit) {
     onShown() = new jfxe.EventHandler[jfxe.Event] {
       override def handle(event: jfxe.Event): Unit = handler(event)
     }

--- a/scalafx/src/main/scala/scalafx/scene/control/ComboBoxBase.scala
+++ b/scalafx/src/main/scala/scalafx/scene/control/ComboBoxBase.scala
@@ -84,6 +84,11 @@ abstract class ComboBoxBase[T](override val delegate: jfxsc.ComboBoxBase[T]) ext
   def onAction_=(v: jfxe.EventHandler[jfxe.ActionEvent]) {
     onAction() = v
   }
+  def onAction_=(handler: jfxe.ActionEvent => Unit) {
+    onAction() = new jfxe.EventHandler[jfxe.ActionEvent] {
+      override def handle(event: jfxe.ActionEvent): Unit = handler(event)
+    }
+  }
 
   /**
    * The ComboBox prompt text to display, or null if no prompt text is displayed.
@@ -118,8 +123,13 @@ abstract class ComboBoxBase[T](override val delegate: jfxsc.ComboBoxBase[T]) ext
    * @since 2.2
    */
   def onHidden = delegate.onHiddenProperty()
-  def onHidden_(eventHandler: jfxe.EventHandler[jfxe.Event]) {
+  def onHidden_=(eventHandler: jfxe.EventHandler[jfxe.Event]) {
     onHidden() = eventHandler
+  }
+  def onHidden_=(handler: jfxe.Event => Unit) {
+    onHidden() = new jfxe.EventHandler[jfxe.Event] {
+      override def handle(event: jfxe.Event): Unit = handler(event)
+    }
   }
 
   /**
@@ -127,8 +137,13 @@ abstract class ComboBoxBase[T](override val delegate: jfxsc.ComboBoxBase[T]) ext
    * @since 2.2
    */
   def onHiding = delegate.onHidingProperty()
-  def onHiding_(eventHandler: jfxe.EventHandler[jfxe.Event]) {
+  def onHiding_=(eventHandler: jfxe.EventHandler[jfxe.Event]) {
     onHiding() = eventHandler
+  }
+  def onHiding_=(handler: jfxe.Event => Unit) {
+    onHiding() = new jfxe.EventHandler[jfxe.Event] {
+      override def handle(event: jfxe.Event): Unit = handler(event)
+    }
   }
 
   /**
@@ -136,8 +151,13 @@ abstract class ComboBoxBase[T](override val delegate: jfxsc.ComboBoxBase[T]) ext
    * @since 2.2
    */
   def onShowing = delegate.onShowingProperty()
-  def onShowing_(eventHandler: jfxe.EventHandler[jfxe.Event]) {
+  def onShowing_=(eventHandler: jfxe.EventHandler[jfxe.Event]) {
     onShowing() = eventHandler
+  }
+  def onShowing_=(handler: jfxe.Event => Unit) {
+    onShowing() = new jfxe.EventHandler[jfxe.Event] {
+      override def handle(event: jfxe.Event): Unit = handler(event)
+    }
   }
 
   /**
@@ -145,8 +165,13 @@ abstract class ComboBoxBase[T](override val delegate: jfxsc.ComboBoxBase[T]) ext
    * @since 2.2
    */
   def onShown = delegate.onShownProperty()
-  def onShown_(eventHandler: jfxe.EventHandler[jfxe.Event]) {
+  def onShown_=(eventHandler: jfxe.EventHandler[jfxe.Event]) {
     onShown() = eventHandler
+  }
+  def onShown_=(handler: jfxe.Event => Unit) {
+    onShown() = new jfxe.EventHandler[jfxe.Event] {
+      override def handle(event: jfxe.Event): Unit = handler(event)
+    }
   }
 
 }

--- a/scalafx/src/main/scala/scalafx/scene/control/ContextMenu.scala
+++ b/scalafx/src/main/scala/scalafx/scene/control/ContextMenu.scala
@@ -58,6 +58,11 @@ class ContextMenu(override val delegate: jfxsc.ContextMenu = new jfxsc.ContextMe
   def onAction_=(v: jfxe.EventHandler[jfxe.ActionEvent]) {
     onAction() = v
   }
+  def onAction_=(handler: jfxe.ActionEvent => Unit) {
+    onAction() = new jfxe.EventHandler[jfxe.ActionEvent] {
+      override def handle(event: jfxe.ActionEvent): Unit = handler(event)
+    }
+  }
 
   /**
    * The menu items on the context menu.

--- a/scalafx/src/main/scala/scalafx/scene/control/ContextMenu.scala
+++ b/scalafx/src/main/scala/scalafx/scene/control/ContextMenu.scala
@@ -33,6 +33,7 @@ import scala.language.implicitConversions
 import scalafx.Includes._
 import scalafx.collections.ObservableBuffer
 import scalafx.delegate.SFXDelegate
+import scalafx.event.ActionEvent
 import scalafx.scene.Node
 
 object ContextMenu {
@@ -58,7 +59,7 @@ class ContextMenu(override val delegate: jfxsc.ContextMenu = new jfxsc.ContextMe
   def onAction_=(v: jfxe.EventHandler[jfxe.ActionEvent]) {
     onAction() = v
   }
-  def onAction_=(handler: jfxe.ActionEvent => Unit) {
+  def onAction_=(handler: ActionEvent => Unit) {
     onAction() = new jfxe.EventHandler[jfxe.ActionEvent] {
       override def handle(event: jfxe.ActionEvent): Unit = handler(event)
     }

--- a/scalafx/src/main/scala/scalafx/scene/control/Dialog.scala
+++ b/scalafx/src/main/scala/scalafx/scene/control/Dialog.scala
@@ -309,6 +309,11 @@ class Dialog[R](override val delegate: jfxsc.Dialog[R] = new jfxsc.Dialog[R]())
   def onShowing_=(v: jfxe.EventHandler[jfxsc.DialogEvent]) {
     onShowing() = v
   }
+  def onShowing_=(handler: jfxsc.DialogEvent => Unit) {
+    onShowing() = new jfxe.EventHandler[jfxsc.DialogEvent] {
+      override def handle(event: jfxsc.DialogEvent): Unit = handler(event)
+    }
+  }
 
   /**
    * Called just after the Dialog is shown.
@@ -317,6 +322,11 @@ class Dialog[R](override val delegate: jfxsc.Dialog[R] = new jfxsc.Dialog[R]())
   def onShown_=(v: jfxe.EventHandler[jfxsc.DialogEvent]) {
     onShown() = v
   }
+  def onShown_=(handler: jfxsc.DialogEvent => Unit) {
+    onShown() = new jfxe.EventHandler[jfxsc.DialogEvent] {
+      override def handle(event: jfxsc.DialogEvent): Unit = handler(event)
+    }
+  }
 
   /**
    * Called just prior to the Dialog being hidden.
@@ -324,6 +334,11 @@ class Dialog[R](override val delegate: jfxsc.Dialog[R] = new jfxsc.Dialog[R]())
   def onHiding = delegate.onHidingProperty
   def onHiding_=(v: jfxe.EventHandler[jfxsc.DialogEvent]) {
     onHiding() = v
+  }
+  def onHiding_=(handler: jfxsc.DialogEvent => Unit) {
+    onHiding() = new jfxe.EventHandler[jfxsc.DialogEvent] {
+      override def handle(event: jfxsc.DialogEvent): Unit = handler(event)
+    }
   }
 
   /**
@@ -336,10 +351,20 @@ class Dialog[R](override val delegate: jfxsc.Dialog[R] = new jfxsc.Dialog[R]())
   def onHidden_=(v: jfxe.EventHandler[jfxsc.DialogEvent]) {
     onHidden() = v
   }
+  def onHidden_=(handler: jfxsc.DialogEvent => Unit) {
+    onHidden() = new jfxe.EventHandler[jfxsc.DialogEvent] {
+      override def handle(event: jfxsc.DialogEvent): Unit = handler(event)
+    }
+  }
 
   def onCloseRequest = delegate.onCloseRequestProperty
   def onCloseRequest_=(v: jfxe.EventHandler[jfxsc.DialogEvent]) {
     onCloseRequest() = v
+  }
+  def onCloseRequest_=(handler: jfxsc.DialogEvent => Unit) {
+    onCloseRequest() = new jfxe.EventHandler[jfxsc.DialogEvent] {
+      override def handle(event: jfxsc.DialogEvent): Unit = handler(event)
+    }
   }
 
 }

--- a/scalafx/src/main/scala/scalafx/scene/control/Dialog.scala
+++ b/scalafx/src/main/scala/scalafx/scene/control/Dialog.scala
@@ -309,7 +309,7 @@ class Dialog[R](override val delegate: jfxsc.Dialog[R] = new jfxsc.Dialog[R]())
   def onShowing_=(v: jfxe.EventHandler[jfxsc.DialogEvent]) {
     onShowing() = v
   }
-  def onShowing_=(handler: jfxsc.DialogEvent => Unit) {
+  def onShowing_=(handler: DialogEvent => Unit) {
     onShowing() = new jfxe.EventHandler[jfxsc.DialogEvent] {
       override def handle(event: jfxsc.DialogEvent): Unit = handler(event)
     }
@@ -322,7 +322,7 @@ class Dialog[R](override val delegate: jfxsc.Dialog[R] = new jfxsc.Dialog[R]())
   def onShown_=(v: jfxe.EventHandler[jfxsc.DialogEvent]) {
     onShown() = v
   }
-  def onShown_=(handler: jfxsc.DialogEvent => Unit) {
+  def onShown_=(handler: DialogEvent => Unit) {
     onShown() = new jfxe.EventHandler[jfxsc.DialogEvent] {
       override def handle(event: jfxsc.DialogEvent): Unit = handler(event)
     }
@@ -335,7 +335,7 @@ class Dialog[R](override val delegate: jfxsc.Dialog[R] = new jfxsc.Dialog[R]())
   def onHiding_=(v: jfxe.EventHandler[jfxsc.DialogEvent]) {
     onHiding() = v
   }
-  def onHiding_=(handler: jfxsc.DialogEvent => Unit) {
+  def onHiding_=(handler: DialogEvent => Unit) {
     onHiding() = new jfxe.EventHandler[jfxsc.DialogEvent] {
       override def handle(event: jfxsc.DialogEvent): Unit = handler(event)
     }
@@ -351,7 +351,7 @@ class Dialog[R](override val delegate: jfxsc.Dialog[R] = new jfxsc.Dialog[R]())
   def onHidden_=(v: jfxe.EventHandler[jfxsc.DialogEvent]) {
     onHidden() = v
   }
-  def onHidden_=(handler: jfxsc.DialogEvent => Unit) {
+  def onHidden_=(handler: DialogEvent => Unit) {
     onHidden() = new jfxe.EventHandler[jfxsc.DialogEvent] {
       override def handle(event: jfxsc.DialogEvent): Unit = handler(event)
     }
@@ -361,7 +361,7 @@ class Dialog[R](override val delegate: jfxsc.Dialog[R] = new jfxsc.Dialog[R]())
   def onCloseRequest_=(v: jfxe.EventHandler[jfxsc.DialogEvent]) {
     onCloseRequest() = v
   }
-  def onCloseRequest_=(handler: jfxsc.DialogEvent => Unit) {
+  def onCloseRequest_=(handler: DialogEvent => Unit) {
     onCloseRequest() = new jfxe.EventHandler[jfxsc.DialogEvent] {
       override def handle(event: jfxsc.DialogEvent): Unit = handler(event)
     }

--- a/scalafx/src/main/scala/scalafx/scene/control/ListView.scala
+++ b/scalafx/src/main/scala/scalafx/scene/control/ListView.scala
@@ -175,6 +175,11 @@ class ListView[T](override val delegate: jfxsc.ListView[T] = new jfxsc.ListView[
   def onEditCancel_=(v: jfxe.EventHandler[jfxsc.ListView.EditEvent[T]]) {
     onEditCancel() = v
   }
+  def onEditCancel_=(handler: jfxsc.ListView.EditEvent[T] => Unit) {
+    onEditCancel() = new jfxe.EventHandler[jfxsc.ListView.EditEvent[T]] {
+      override def handle(event: jfxsc.ListView.EditEvent[T]): Unit = handler(event)
+    }
+  }
 
   /**
    * This property is used when the user performs an action that should result in their editing
@@ -184,6 +189,11 @@ class ListView[T](override val delegate: jfxsc.ListView[T] = new jfxsc.ListView[
   def onEditCommit_=(v: jfxe.EventHandler[jfxsc.ListView.EditEvent[T]]) {
     onEditCommit() = v
   }
+  def onEditCommit_=(handler: jfxsc.ListView.EditEvent[T] => Unit) {
+    onEditCommit() = new jfxe.EventHandler[jfxsc.ListView.EditEvent[T]] {
+      override def handle(event: jfxsc.ListView.EditEvent[T]): Unit = handler(event)
+    }
+  }
 
   /**
    * This event handler will be fired when the user successfully initiates editing.
@@ -191,6 +201,11 @@ class ListView[T](override val delegate: jfxsc.ListView[T] = new jfxsc.ListView[
   def onEditStart = delegate.onEditStartProperty
   def onEditStart_=(v: jfxe.EventHandler[jfxsc.ListView.EditEvent[T]]) {
     onEditStart() = v
+  }
+  def onEditStart_=(handler: jfxsc.ListView.EditEvent[T] => Unit) {
+    onEditStart() = new jfxe.EventHandler[jfxsc.ListView.EditEvent[T]] {
+      override def handle(event: jfxsc.ListView.EditEvent[T]): Unit = handler(event)
+    }
   }
 
   /**
@@ -231,6 +246,14 @@ class ListView[T](override val delegate: jfxsc.ListView[T] = new jfxsc.ListView[
   def onScrollTo: ObjectProperty[jfxe.EventHandler[jfxsc.ScrollToEvent[Integer]]] = delegate.onScrollToProperty
   def onScrollTo_=(v: jfxe.EventHandler[jfxsc.ScrollToEvent[Integer]]) {
     ObjectProperty.fillProperty[jfxe.EventHandler[jfxsc.ScrollToEvent[Integer]]](onScrollTo, v)
+  }
+  def onScrollTo_=(handler: jfxsc.ScrollToEvent[Integer] => Unit) {
+    ObjectProperty.fillProperty[jfxe.EventHandler[jfxsc.ScrollToEvent[Integer]]](
+      onScrollTo,
+      new jfxe.EventHandler[jfxsc.ScrollToEvent[Integer]] {
+        override def handle(event: jfxsc.ScrollToEvent[Integer]): Unit = handler(event)
+      }
+    )
   }
 
   /**

--- a/scalafx/src/main/scala/scalafx/scene/control/ListView.scala
+++ b/scalafx/src/main/scala/scalafx/scene/control/ListView.scala
@@ -175,7 +175,7 @@ class ListView[T](override val delegate: jfxsc.ListView[T] = new jfxsc.ListView[
   def onEditCancel_=(v: jfxe.EventHandler[jfxsc.ListView.EditEvent[T]]) {
     onEditCancel() = v
   }
-  def onEditCancel_=(handler: jfxsc.ListView.EditEvent[T] => Unit) {
+  def onEditCancel_=(handler: ListView.EditEvent[T] => Unit) {
     onEditCancel() = new jfxe.EventHandler[jfxsc.ListView.EditEvent[T]] {
       override def handle(event: jfxsc.ListView.EditEvent[T]): Unit = handler(event)
     }
@@ -189,7 +189,7 @@ class ListView[T](override val delegate: jfxsc.ListView[T] = new jfxsc.ListView[
   def onEditCommit_=(v: jfxe.EventHandler[jfxsc.ListView.EditEvent[T]]) {
     onEditCommit() = v
   }
-  def onEditCommit_=(handler: jfxsc.ListView.EditEvent[T] => Unit) {
+  def onEditCommit_=(handler: ListView.EditEvent[T] => Unit) {
     onEditCommit() = new jfxe.EventHandler[jfxsc.ListView.EditEvent[T]] {
       override def handle(event: jfxsc.ListView.EditEvent[T]): Unit = handler(event)
     }
@@ -202,7 +202,7 @@ class ListView[T](override val delegate: jfxsc.ListView[T] = new jfxsc.ListView[
   def onEditStart_=(v: jfxe.EventHandler[jfxsc.ListView.EditEvent[T]]) {
     onEditStart() = v
   }
-  def onEditStart_=(handler: jfxsc.ListView.EditEvent[T] => Unit) {
+  def onEditStart_=(handler: ListView.EditEvent[T] => Unit) {
     onEditStart() = new jfxe.EventHandler[jfxsc.ListView.EditEvent[T]] {
       override def handle(event: jfxsc.ListView.EditEvent[T]): Unit = handler(event)
     }
@@ -247,7 +247,7 @@ class ListView[T](override val delegate: jfxsc.ListView[T] = new jfxsc.ListView[
   def onScrollTo_=(v: jfxe.EventHandler[jfxsc.ScrollToEvent[Integer]]) {
     ObjectProperty.fillProperty[jfxe.EventHandler[jfxsc.ScrollToEvent[Integer]]](onScrollTo, v)
   }
-  def onScrollTo_=(handler: jfxsc.ScrollToEvent[Integer] => Unit) {
+  def onScrollTo_=(handler: ScrollToEvent[Integer] => Unit) {
     ObjectProperty.fillProperty[jfxe.EventHandler[jfxsc.ScrollToEvent[Integer]]](
       onScrollTo,
       new jfxe.EventHandler[jfxsc.ScrollToEvent[Integer]] {

--- a/scalafx/src/main/scala/scalafx/scene/control/Menu.scala
+++ b/scalafx/src/main/scala/scalafx/scene/control/Menu.scala
@@ -33,6 +33,7 @@ import scala.language.implicitConversions
 import scalafx.Includes._
 import scalafx.collections._
 import scalafx.delegate.SFXDelegate
+import scalafx.event.Event
 import scalafx.scene.Node
 import scalafx.scene.Node._
 
@@ -95,7 +96,7 @@ class Menu(override val delegate: jfxsc.Menu = new jfxsc.Menu("default"))
   def onHidden_=(implicit eventHandler: jfxe.EventHandler[jfxe.Event]) {
     onHidden() = eventHandler
   }
-  def onHidden_=(handler: jfxe.Event => Unit) {
+  def onHidden_=(handler: Event => Unit) {
     onHidden() = new jfxe.EventHandler[jfxe.Event] {
       override def handle(event: jfxe.Event): Unit = handler(event)
     }
@@ -105,7 +106,7 @@ class Menu(override val delegate: jfxsc.Menu = new jfxsc.Menu("default"))
   def onHiding_=(implicit eventHandler: jfxe.EventHandler[jfxe.Event]) {
     onHiding() = eventHandler
   }
-  def onHiding_=(handler: jfxe.Event => Unit) {
+  def onHiding_=(handler: Event => Unit) {
     onHiding() = new jfxe.EventHandler[jfxe.Event] {
       override def handle(event: jfxe.Event): Unit = handler(event)
     }
@@ -115,7 +116,7 @@ class Menu(override val delegate: jfxsc.Menu = new jfxsc.Menu("default"))
   def onShowing_=(implicit eventHandler: jfxe.EventHandler[jfxe.Event]) {
     onShowing() = eventHandler
   }
-  def onShowing_=(handler: jfxe.Event => Unit) {
+  def onShowing_=(handler: Event => Unit) {
     onShowing() = new jfxe.EventHandler[jfxe.Event] {
       override def handle(event: jfxe.Event): Unit = handler(event)
     }
@@ -125,7 +126,7 @@ class Menu(override val delegate: jfxsc.Menu = new jfxsc.Menu("default"))
   def onShown_=(implicit eventHandler: jfxe.EventHandler[jfxe.Event]) {
     onShown() = eventHandler
   }
-  def onShown_=(handler: jfxe.Event => Unit) {
+  def onShown_=(handler: Event => Unit) {
     onShown() = new jfxe.EventHandler[jfxe.Event] {
       override def handle(event: jfxe.Event): Unit = handler(event)
     }

--- a/scalafx/src/main/scala/scalafx/scene/control/Menu.scala
+++ b/scalafx/src/main/scala/scalafx/scene/control/Menu.scala
@@ -95,20 +95,40 @@ class Menu(override val delegate: jfxsc.Menu = new jfxsc.Menu("default"))
   def onHidden_=(implicit eventHandler: jfxe.EventHandler[jfxe.Event]) {
     onHidden() = eventHandler
   }
+  def onHidden_=(handler: jfxe.Event => Unit) {
+    onHidden() = new jfxe.EventHandler[jfxe.Event] {
+      override def handle(event: jfxe.Event): Unit = handler(event)
+    }
+  }
 
   def onHiding = delegate.onHidingProperty
   def onHiding_=(implicit eventHandler: jfxe.EventHandler[jfxe.Event]) {
     onHiding() = eventHandler
+  }
+  def onHiding_=(handler: jfxe.Event => Unit) {
+    onHiding() = new jfxe.EventHandler[jfxe.Event] {
+      override def handle(event: jfxe.Event): Unit = handler(event)
+    }
   }
 
   def onShowing = delegate.onShowingProperty
   def onShowing_=(implicit eventHandler: jfxe.EventHandler[jfxe.Event]) {
     onShowing() = eventHandler
   }
+  def onShowing_=(handler: jfxe.Event => Unit) {
+    onShowing() = new jfxe.EventHandler[jfxe.Event] {
+      override def handle(event: jfxe.Event): Unit = handler(event)
+    }
+  }
 
   def onShown = delegate.onShownProperty
   def onShown_=(implicit eventHandler: jfxe.EventHandler[jfxe.Event]) {
     onShown() = eventHandler
+  }
+  def onShown_=(handler: jfxe.Event => Unit) {
+    onShown() = new jfxe.EventHandler[jfxe.Event] {
+      override def handle(event: jfxe.Event): Unit = handler(event)
+    }
   }
 
 }

--- a/scalafx/src/main/scala/scalafx/scene/control/MenuItem.scala
+++ b/scalafx/src/main/scala/scalafx/scene/control/MenuItem.scala
@@ -107,6 +107,11 @@ class MenuItem(override val delegate: jfxsc.MenuItem = new jfxsc.MenuItem)
   def onAction_=(v: jfxe.EventHandler[jfxe.ActionEvent]) {
     onAction() = v
   }
+  def onAction_=(handler: jfxe.ActionEvent => Unit) {
+    onAction() = new jfxe.EventHandler[jfxe.ActionEvent] {
+      override def handle(event: jfxe.ActionEvent): Unit = handler(event)
+    }
+  }
 
   /**
    *
@@ -167,6 +172,11 @@ class MenuItem(override val delegate: jfxsc.MenuItem = new jfxsc.MenuItem)
   def onMenuValidation = delegate.onMenuValidationProperty()
   def onMenuValidation_=(eventHandler: jfxe.EventHandler[jfxe.Event]) {
     onMenuValidation() = eventHandler
+  }
+  def onMenuValidation_=(handler: jfxe.Event => Unit) {
+    onMenuValidation() = new jfxe.EventHandler[jfxe.Event] {
+      override def handle(event: jfxe.Event): Unit = handler(event)
+    }
   }
 
   override protected def eventHandlerDelegate = delegate.asInstanceOf[EventHandled]

--- a/scalafx/src/main/scala/scalafx/scene/control/MenuItem.scala
+++ b/scalafx/src/main/scala/scalafx/scene/control/MenuItem.scala
@@ -34,7 +34,7 @@ import scalafx.Includes._
 import scalafx.beans.property.{BooleanProperty, ObjectProperty, ReadOnlyObjectProperty, StringProperty}
 import scalafx.css.Styleable
 import scalafx.delegate.{FireDelegate, SFXDelegate}
-import scalafx.event.EventHandlerDelegate
+import scalafx.event.{Event, ActionEvent, EventHandlerDelegate}
 import scalafx.scene.Node
 import scalafx.scene.input.KeyCombination
 
@@ -107,7 +107,7 @@ class MenuItem(override val delegate: jfxsc.MenuItem = new jfxsc.MenuItem)
   def onAction_=(v: jfxe.EventHandler[jfxe.ActionEvent]) {
     onAction() = v
   }
-  def onAction_=(handler: jfxe.ActionEvent => Unit) {
+  def onAction_=(handler: ActionEvent => Unit) {
     onAction() = new jfxe.EventHandler[jfxe.ActionEvent] {
       override def handle(event: jfxe.ActionEvent): Unit = handler(event)
     }
@@ -173,7 +173,7 @@ class MenuItem(override val delegate: jfxsc.MenuItem = new jfxsc.MenuItem)
   def onMenuValidation_=(eventHandler: jfxe.EventHandler[jfxe.Event]) {
     onMenuValidation() = eventHandler
   }
-  def onMenuValidation_=(handler: jfxe.Event => Unit) {
+  def onMenuValidation_=(handler: Event => Unit) {
     onMenuValidation() = new jfxe.EventHandler[jfxe.Event] {
       override def handle(event: jfxe.Event): Unit = handler(event)
     }

--- a/scalafx/src/main/scala/scalafx/scene/control/Tab.scala
+++ b/scalafx/src/main/scala/scalafx/scene/control/Tab.scala
@@ -34,6 +34,7 @@ import scalafx.Includes._
 import scalafx.beans.property.{BooleanProperty, ObjectProperty, ReadOnlyBooleanProperty, ReadOnlyObjectProperty, StringProperty}
 import scalafx.css.Styleable
 import scalafx.delegate.SFXDelegate
+import scalafx.event.Event
 import scalafx.scene.Node
 import scalafx.scene.Node._
 
@@ -94,7 +95,7 @@ class Tab(override val delegate: jfxsc.Tab = new jfxsc.Tab)
   def onClosed_=(v: jfxe.EventHandler[jfxe.Event]) {
     onClosed() = v
   }
-  def onClosed_=(handler: jfxe.Event => Unit) {
+  def onClosed_=(handler: Event => Unit) {
     onClosed() = new jfxe.EventHandler[jfxe.Event] {
       override def handle(event: jfxe.Event): Unit = handler(event)
     }
@@ -107,7 +108,7 @@ class Tab(override val delegate: jfxsc.Tab = new jfxsc.Tab)
   def onCloseRequest_=(v: jfxe.EventHandler[jfxe.Event]) {
     ObjectProperty.fillProperty[jfxe.EventHandler[jfxe.Event]](onCloseRequest, v)
   }
-  def onCloseRequest_=(handler: jfxe.Event => Unit) {
+  def onCloseRequest_=(handler: Event => Unit) {
     ObjectProperty.fillProperty[jfxe.EventHandler[jfxe.Event]](
       onCloseRequest,
       new jfxe.EventHandler[jfxe.Event] {
@@ -123,7 +124,7 @@ class Tab(override val delegate: jfxsc.Tab = new jfxsc.Tab)
   def onSelectionChanged_=(v: jfxe.EventHandler[jfxe.Event]) {
     onSelectionChanged() = v
   }
-  def onSelectionChanged_=(handler: jfxe.Event => Unit) {
+  def onSelectionChanged_=(handler: Event => Unit) {
     onSelectionChanged() = new jfxe.EventHandler[jfxe.Event] {
       override def handle(event: jfxe.Event): Unit = handler(event)
     }

--- a/scalafx/src/main/scala/scalafx/scene/control/Tab.scala
+++ b/scalafx/src/main/scala/scalafx/scene/control/Tab.scala
@@ -94,6 +94,11 @@ class Tab(override val delegate: jfxsc.Tab = new jfxsc.Tab)
   def onClosed_=(v: jfxe.EventHandler[jfxe.Event]) {
     onClosed() = v
   }
+  def onClosed_=(handler: jfxe.Event => Unit) {
+    onClosed() = new jfxe.EventHandler[jfxe.Event] {
+      override def handle(event: jfxe.Event): Unit = handler(event)
+    }
+  }
 
   /**
    * Called when there is an external request to close this Tab.
@@ -102,6 +107,14 @@ class Tab(override val delegate: jfxsc.Tab = new jfxsc.Tab)
   def onCloseRequest_=(v: jfxe.EventHandler[jfxe.Event]) {
     ObjectProperty.fillProperty[jfxe.EventHandler[jfxe.Event]](onCloseRequest, v)
   }
+  def onCloseRequest_=(handler: jfxe.Event => Unit) {
+    ObjectProperty.fillProperty[jfxe.EventHandler[jfxe.Event]](
+      onCloseRequest,
+      new jfxe.EventHandler[jfxe.Event] {
+        override def handle(event: jfxe.Event): Unit = handler(event)
+      }
+    )
+  }
 
   /**
    * The event handler that is associated with a selection on the tab.
@@ -109,6 +122,11 @@ class Tab(override val delegate: jfxsc.Tab = new jfxsc.Tab)
   def onSelectionChanged = delegate.onSelectionChangedProperty
   def onSelectionChanged_=(v: jfxe.EventHandler[jfxe.Event]) {
     onSelectionChanged() = v
+  }
+  def onSelectionChanged_=(handler: jfxe.Event => Unit) {
+    onSelectionChanged() = new jfxe.EventHandler[jfxe.Event] {
+      override def handle(event: jfxe.Event): Unit = handler(event)
+    }
   }
 
   /**

--- a/scalafx/src/main/scala/scalafx/scene/control/TableColumn.scala
+++ b/scalafx/src/main/scala/scalafx/scene/control/TableColumn.scala
@@ -247,6 +247,11 @@ class TableColumn[S, T](override val delegate: jfxsc.TableColumn[S, T] = new jfx
   def onEditCancel_=(v: jfxe.EventHandler[jfxsc.TableColumn.CellEditEvent[S, T]]) {
     onEditCancel() = v
   }
+  def onEditCancel_=(handler: jfxsc.TableColumn.CellEditEvent[S, T] => Unit) {
+    onEditCancel() = new jfxe.EventHandler[jfxsc.TableColumn.CellEditEvent[S, T]] {
+      override def handle(event: jfxsc.TableColumn.CellEditEvent[S, T]): Unit = handler(event)
+    }
+  }
 
   /**
    * This event handler will be fired when the user successfully commits their editing.
@@ -255,6 +260,11 @@ class TableColumn[S, T](override val delegate: jfxsc.TableColumn[S, T] = new jfx
   def onEditCommit_=(v: jfxe.EventHandler[jfxsc.TableColumn.CellEditEvent[S, T]]) {
     onEditCommit() = v
   }
+  def onEditCommit_=(handler: jfxsc.TableColumn.CellEditEvent[S, T] => Unit) {
+    onEditCommit() = new jfxe.EventHandler[jfxsc.TableColumn.CellEditEvent[S, T]] {
+      override def handle(event: jfxsc.TableColumn.CellEditEvent[S, T]): Unit = handler(event)
+    }
+  }
 
   /**
    * This event handler will be fired when the user successfully initiates editing.
@@ -262,6 +272,11 @@ class TableColumn[S, T](override val delegate: jfxsc.TableColumn[S, T] = new jfx
   def onEditStart = delegate.onEditCommitProperty
   def onEditStart_=(v: jfxe.EventHandler[jfxsc.TableColumn.CellEditEvent[S, T]]) {
     onEditStart() = v
+  }
+  def onEditStart_=(handler: jfxsc.TableColumn.CellEditEvent[S, T] => Unit) {
+    onEditStart() = new jfxe.EventHandler[jfxsc.TableColumn.CellEditEvent[S, T]] {
+      override def handle(event: jfxsc.TableColumn.CellEditEvent[S, T]): Unit = handler(event)
+    }
   }
 
   /**

--- a/scalafx/src/main/scala/scalafx/scene/control/TableColumn.scala
+++ b/scalafx/src/main/scala/scalafx/scene/control/TableColumn.scala
@@ -247,7 +247,7 @@ class TableColumn[S, T](override val delegate: jfxsc.TableColumn[S, T] = new jfx
   def onEditCancel_=(v: jfxe.EventHandler[jfxsc.TableColumn.CellEditEvent[S, T]]) {
     onEditCancel() = v
   }
-  def onEditCancel_=(handler: jfxsc.TableColumn.CellEditEvent[S, T] => Unit) {
+  def onEditCancel_=(handler: TableColumn.CellEditEvent[S, T] => Unit) {
     onEditCancel() = new jfxe.EventHandler[jfxsc.TableColumn.CellEditEvent[S, T]] {
       override def handle(event: jfxsc.TableColumn.CellEditEvent[S, T]): Unit = handler(event)
     }
@@ -260,7 +260,7 @@ class TableColumn[S, T](override val delegate: jfxsc.TableColumn[S, T] = new jfx
   def onEditCommit_=(v: jfxe.EventHandler[jfxsc.TableColumn.CellEditEvent[S, T]]) {
     onEditCommit() = v
   }
-  def onEditCommit_=(handler: jfxsc.TableColumn.CellEditEvent[S, T] => Unit) {
+  def onEditCommit_=(handler: TableColumn.CellEditEvent[S, T] => Unit) {
     onEditCommit() = new jfxe.EventHandler[jfxsc.TableColumn.CellEditEvent[S, T]] {
       override def handle(event: jfxsc.TableColumn.CellEditEvent[S, T]): Unit = handler(event)
     }
@@ -273,7 +273,7 @@ class TableColumn[S, T](override val delegate: jfxsc.TableColumn[S, T] = new jfx
   def onEditStart_=(v: jfxe.EventHandler[jfxsc.TableColumn.CellEditEvent[S, T]]) {
     onEditStart() = v
   }
-  def onEditStart_=(handler: jfxsc.TableColumn.CellEditEvent[S, T] => Unit) {
+  def onEditStart_=(handler: TableColumn.CellEditEvent[S, T] => Unit) {
     onEditStart() = new jfxe.EventHandler[jfxsc.TableColumn.CellEditEvent[S, T]] {
       override def handle(event: jfxsc.TableColumn.CellEditEvent[S, T]): Unit = handler(event)
     }

--- a/scalafx/src/main/scala/scalafx/scene/control/TableView.scala
+++ b/scalafx/src/main/scala/scalafx/scene/control/TableView.scala
@@ -417,7 +417,7 @@ class TableView[S](override val delegate: jfxsc.TableView[S] = new jfxsc.TableVi
   def onScrollTo_=(v: jfxe.EventHandler[jfxsc.ScrollToEvent[Integer]]) {
     ObjectProperty.fillProperty[jfxe.EventHandler[jfxsc.ScrollToEvent[Integer]]](onScrollTo, v)
   }
-  def onScrollTo_=(handler: jfxsc.ScrollToEvent[Integer] => Unit) {
+  def onScrollTo_=(handler: ScrollToEvent[Integer] => Unit) {
     ObjectProperty.fillProperty[jfxe.EventHandler[jfxsc.ScrollToEvent[Integer]]](
       onScrollTo,
       new jfxe.EventHandler[jfxsc.ScrollToEvent[Integer]] {
@@ -433,7 +433,7 @@ class TableView[S](override val delegate: jfxsc.TableView[S] = new jfxsc.TableVi
   def onScrollToColumn_=(v: jfxe.EventHandler[jfxsc.ScrollToEvent[jfxsc.TableColumn[S, _]]]) {
     ObjectProperty.fillProperty[jfxe.EventHandler[jfxsc.ScrollToEvent[jfxsc.TableColumn[S, _]]]](onScrollToColumn, v)
   }
-  def onScrollToColumn_=(handler: jfxsc.ScrollToEvent[jfxsc.TableColumn[S, _]] => Unit) {
+  def onScrollToColumn_=(handler: ScrollToEvent[jfxsc.TableColumn[S, _]] => Unit) {
     ObjectProperty.fillProperty[jfxe.EventHandler[jfxsc.ScrollToEvent[jfxsc.TableColumn[S, _]]]](
       onScrollToColumn,
       new jfxe.EventHandler[jfxsc.ScrollToEvent[jfxsc.TableColumn[S, _]]] {
@@ -447,7 +447,7 @@ class TableView[S](override val delegate: jfxsc.TableView[S] = new jfxsc.TableVi
   def onSort_=(v: jfxe.EventHandler[jfxsc.SortEvent[jfxsc.TableView[S]]]) {
     ObjectProperty.fillProperty[jfxe.EventHandler[jfxsc.SortEvent[jfxsc.TableView[S]]]](onSort, v)
   }
-  def onSort_=(handler: jfxsc.SortEvent[jfxsc.TableView[S]] => Unit) {
+  def onSort_=(handler: SortEvent[jfxsc.TableView[S]] => Unit) {
     ObjectProperty.fillProperty[jfxe.EventHandler[jfxsc.SortEvent[jfxsc.TableView[S]]]](
       onSort,
       new jfxe.EventHandler[jfxsc.SortEvent[jfxsc.TableView[S]]] {

--- a/scalafx/src/main/scala/scalafx/scene/control/TableView.scala
+++ b/scalafx/src/main/scala/scalafx/scene/control/TableView.scala
@@ -417,6 +417,14 @@ class TableView[S](override val delegate: jfxsc.TableView[S] = new jfxsc.TableVi
   def onScrollTo_=(v: jfxe.EventHandler[jfxsc.ScrollToEvent[Integer]]) {
     ObjectProperty.fillProperty[jfxe.EventHandler[jfxsc.ScrollToEvent[Integer]]](onScrollTo, v)
   }
+  def onScrollTo_=(handler: jfxsc.ScrollToEvent[Integer] => Unit) {
+    ObjectProperty.fillProperty[jfxe.EventHandler[jfxsc.ScrollToEvent[Integer]]](
+      onScrollTo,
+      new jfxe.EventHandler[jfxsc.ScrollToEvent[Integer]] {
+        override def handle(event: jfxsc.ScrollToEvent[Integer]): Unit = handler(event)
+      }
+    )
+  }
 
   /**
    * Called when there's a request to scroll a column into view using `scrollToColumn(TableColumn)` or `scrollToColumnIndex(int)`.
@@ -425,11 +433,27 @@ class TableView[S](override val delegate: jfxsc.TableView[S] = new jfxsc.TableVi
   def onScrollToColumn_=(v: jfxe.EventHandler[jfxsc.ScrollToEvent[jfxsc.TableColumn[S, _]]]) {
     ObjectProperty.fillProperty[jfxe.EventHandler[jfxsc.ScrollToEvent[jfxsc.TableColumn[S, _]]]](onScrollToColumn, v)
   }
+  def onScrollToColumn_=(handler: jfxsc.ScrollToEvent[jfxsc.TableColumn[S, _]] => Unit) {
+    ObjectProperty.fillProperty[jfxe.EventHandler[jfxsc.ScrollToEvent[jfxsc.TableColumn[S, _]]]](
+      onScrollToColumn,
+      new jfxe.EventHandler[jfxsc.ScrollToEvent[jfxsc.TableColumn[S, _]]] {
+        override def handle(event: jfxsc.ScrollToEvent[jfxsc.TableColumn[S, _]]): Unit = handler(event)
+      }
+    )
+  }
 
   /** Called when there's a request to sort the control. */
   def onSort: ObjectProperty[jfxe.EventHandler[jfxsc.SortEvent[jfxsc.TableView[S]]]] = delegate.onSortProperty
   def onSort_=(v: jfxe.EventHandler[jfxsc.SortEvent[jfxsc.TableView[S]]]) {
     ObjectProperty.fillProperty[jfxe.EventHandler[jfxsc.SortEvent[jfxsc.TableView[S]]]](onSort, v)
+  }
+  def onSort_=(handler: jfxsc.SortEvent[jfxsc.TableView[S]] => Unit) {
+    ObjectProperty.fillProperty[jfxe.EventHandler[jfxsc.SortEvent[jfxsc.TableView[S]]]](
+      onSort,
+      new jfxe.EventHandler[jfxsc.SortEvent[jfxsc.TableView[S]]] {
+        override def handle(event: jfxsc.SortEvent[jfxsc.TableView[S]]): Unit = handler(event)
+      }
+    )
   }
 
   /**

--- a/scalafx/src/main/scala/scalafx/scene/control/TextField.scala
+++ b/scalafx/src/main/scala/scalafx/scene/control/TextField.scala
@@ -50,6 +50,11 @@ class TextField(override val delegate: jfxsc.TextField = new jfxsc.TextField)
   def onAction_=(v: jfxe.EventHandler[jfxe.ActionEvent]) {
     onAction() = v
   }
+  def onAction_=(handler: jfxe.ActionEvent => Unit) {
+    onAction() = new jfxe.EventHandler[jfxe.ActionEvent] {
+      override def handle(event: jfxe.ActionEvent): Unit = handler(event)
+    }
+  }
 
   /**
    * The preferred number of text columns.

--- a/scalafx/src/main/scala/scalafx/scene/control/TextField.scala
+++ b/scalafx/src/main/scala/scalafx/scene/control/TextField.scala
@@ -33,6 +33,7 @@ import scala.language.implicitConversions
 import scalafx.Includes._
 import scalafx.beans.property.IntegerProperty
 import scalafx.delegate.{AlignmentDelegate, SFXDelegate}
+import scalafx.event.ActionEvent
 
 object TextField {
   implicit def sfxTextField2jfx(v: TextField): jfxsc.TextField = if (v != null) v.delegate else null
@@ -50,7 +51,7 @@ class TextField(override val delegate: jfxsc.TextField = new jfxsc.TextField)
   def onAction_=(v: jfxe.EventHandler[jfxe.ActionEvent]) {
     onAction() = v
   }
-  def onAction_=(handler: jfxe.ActionEvent => Unit) {
+  def onAction_=(handler: ActionEvent => Unit) {
     onAction() = new jfxe.EventHandler[jfxe.ActionEvent] {
       override def handle(event: jfxe.ActionEvent): Unit = handler(event)
     }

--- a/scalafx/src/main/scala/scalafx/scene/control/TreeView.scala
+++ b/scalafx/src/main/scala/scalafx/scene/control/TreeView.scala
@@ -178,6 +178,11 @@ class TreeView[T](override val delegate: jfxsc.TreeView[T] = new jfxsc.TreeView[
   def onEditCancel_=(v: jfxe.EventHandler[jfxsc.TreeView.EditEvent[T]]) {
     onEditCancel() = v
   }
+  def onEditCancel_=(handler: jfxsc.TreeView.EditEvent[T] => Unit) {
+    onEditCancel() = new jfxe.EventHandler[jfxsc.TreeView.EditEvent[T]] {
+      override def handle(event: jfxsc.TreeView.EditEvent[T]): Unit = handler(event)
+    }
+  }
 
   /**
    * This event handler will be fired when the user commits editing a cell.
@@ -185,6 +190,11 @@ class TreeView[T](override val delegate: jfxsc.TreeView[T] = new jfxsc.TreeView[
   def onEditCommit = delegate.onEditCommitProperty
   def onEditCommit_=(v: jfxe.EventHandler[jfxsc.TreeView.EditEvent[T]]) {
     onEditCommit() = v
+  }
+  def onEditCommit_=(handler: jfxsc.TreeView.EditEvent[T] => Unit) {
+    onEditCommit() = new jfxe.EventHandler[jfxsc.TreeView.EditEvent[T]] {
+      override def handle(event: jfxsc.TreeView.EditEvent[T]): Unit = handler(event)
+    }
   }
 
   /**
@@ -194,6 +204,11 @@ class TreeView[T](override val delegate: jfxsc.TreeView[T] = new jfxsc.TreeView[
   def onEditStart_=(v: jfxe.EventHandler[jfxsc.TreeView.EditEvent[T]]) {
     onEditStart() = v
   }
+  def onEditStart_=(handler: jfxsc.TreeView.EditEvent[T] => Unit) {
+    onEditStart() = new jfxe.EventHandler[jfxsc.TreeView.EditEvent[T]] {
+      override def handle(event: jfxsc.TreeView.EditEvent[T]): Unit = handler(event)
+    }
+  }
 
   /**
    * Called when there's a request to scroll an index into view using `scrollTo(Int)`
@@ -201,6 +216,14 @@ class TreeView[T](override val delegate: jfxsc.TreeView[T] = new jfxsc.TreeView[
   def onScrollTo: ObjectProperty[jfxe.EventHandler[jfxsc.ScrollToEvent[Integer]]] = delegate.onScrollToProperty
   def onScrollTo_=(v: jfxe.EventHandler[jfxsc.ScrollToEvent[Integer]]) {
     ObjectProperty.fillProperty[jfxe.EventHandler[jfxsc.ScrollToEvent[Integer]]](onScrollTo, v)
+  }
+  def onScrollTo_=(handler: jfxsc.ScrollToEvent[Integer] => Unit) {
+    ObjectProperty.fillProperty[jfxe.EventHandler[jfxsc.ScrollToEvent[Integer]]](
+      onScrollTo,
+      new jfxe.EventHandler[jfxsc.ScrollToEvent[Integer]] {
+        override def handle(event: jfxsc.ScrollToEvent[Integer]): Unit = handler(event)
+      }
+    )
   }
 
   /**

--- a/scalafx/src/main/scala/scalafx/scene/control/TreeView.scala
+++ b/scalafx/src/main/scala/scalafx/scene/control/TreeView.scala
@@ -178,7 +178,7 @@ class TreeView[T](override val delegate: jfxsc.TreeView[T] = new jfxsc.TreeView[
   def onEditCancel_=(v: jfxe.EventHandler[jfxsc.TreeView.EditEvent[T]]) {
     onEditCancel() = v
   }
-  def onEditCancel_=(handler: jfxsc.TreeView.EditEvent[T] => Unit) {
+  def onEditCancel_=(handler: TreeView.EditEvent[T] => Unit) {
     onEditCancel() = new jfxe.EventHandler[jfxsc.TreeView.EditEvent[T]] {
       override def handle(event: jfxsc.TreeView.EditEvent[T]): Unit = handler(event)
     }
@@ -191,7 +191,7 @@ class TreeView[T](override val delegate: jfxsc.TreeView[T] = new jfxsc.TreeView[
   def onEditCommit_=(v: jfxe.EventHandler[jfxsc.TreeView.EditEvent[T]]) {
     onEditCommit() = v
   }
-  def onEditCommit_=(handler: jfxsc.TreeView.EditEvent[T] => Unit) {
+  def onEditCommit_=(handler: TreeView.EditEvent[T] => Unit) {
     onEditCommit() = new jfxe.EventHandler[jfxsc.TreeView.EditEvent[T]] {
       override def handle(event: jfxsc.TreeView.EditEvent[T]): Unit = handler(event)
     }
@@ -204,7 +204,7 @@ class TreeView[T](override val delegate: jfxsc.TreeView[T] = new jfxsc.TreeView[
   def onEditStart_=(v: jfxe.EventHandler[jfxsc.TreeView.EditEvent[T]]) {
     onEditStart() = v
   }
-  def onEditStart_=(handler: jfxsc.TreeView.EditEvent[T] => Unit) {
+  def onEditStart_=(handler: TreeView.EditEvent[T] => Unit) {
     onEditStart() = new jfxe.EventHandler[jfxsc.TreeView.EditEvent[T]] {
       override def handle(event: jfxsc.TreeView.EditEvent[T]): Unit = handler(event)
     }
@@ -217,7 +217,7 @@ class TreeView[T](override val delegate: jfxsc.TreeView[T] = new jfxsc.TreeView[
   def onScrollTo_=(v: jfxe.EventHandler[jfxsc.ScrollToEvent[Integer]]) {
     ObjectProperty.fillProperty[jfxe.EventHandler[jfxsc.ScrollToEvent[Integer]]](onScrollTo, v)
   }
-  def onScrollTo_=(handler: jfxsc.ScrollToEvent[Integer] => Unit) {
+  def onScrollTo_=(handler: ScrollToEvent[Integer] => Unit) {
     ObjectProperty.fillProperty[jfxe.EventHandler[jfxsc.ScrollToEvent[Integer]]](
       onScrollTo,
       new jfxe.EventHandler[jfxsc.ScrollToEvent[Integer]] {

--- a/scalafx/src/main/scala/scalafx/scene/media/MediaPlayer.scala
+++ b/scalafx/src/main/scala/scalafx/scene/media/MediaPlayer.scala
@@ -253,6 +253,11 @@ class MediaPlayer(override val delegate: jfxsm.MediaPlayer) extends SFXDelegate[
   def onMarker_=(v: jfxe.EventHandler[jfxsm.MediaMarkerEvent]) {
     onMarker() = v
   }
+  def onMarker_=(handler: jfxsm.MediaMarkerEvent => Unit) {
+    onMarker() = new jfxe.EventHandler[jfxsm.MediaMarkerEvent] {
+      override def handle(event: jfxsm.MediaMarkerEvent): Unit = handler(event)
+    }
+  }
 
   /**
    * Event handler invoked when the status changes to PAUSED.

--- a/scalafx/src/main/scala/scalafx/scene/media/MediaPlayer.scala
+++ b/scalafx/src/main/scala/scalafx/scene/media/MediaPlayer.scala
@@ -253,7 +253,7 @@ class MediaPlayer(override val delegate: jfxsm.MediaPlayer) extends SFXDelegate[
   def onMarker_=(v: jfxe.EventHandler[jfxsm.MediaMarkerEvent]) {
     onMarker() = v
   }
-  def onMarker_=(handler: jfxsm.MediaMarkerEvent => Unit) {
+  def onMarker_=(handler: MediaMarkerEvent => Unit) {
     onMarker() = new jfxe.EventHandler[jfxsm.MediaMarkerEvent] {
       override def handle(event: jfxsm.MediaMarkerEvent): Unit = handler(event)
     }

--- a/scalafx/src/main/scala/scalafx/scene/media/MediaView.scala
+++ b/scalafx/src/main/scala/scalafx/scene/media/MediaView.scala
@@ -83,6 +83,11 @@ class MediaView(override val delegate: jfxsm.MediaView = new jfxsm.MediaView)
   def onError_=(v: jfxe.EventHandler[jfxsm.MediaErrorEvent]) {
     onError() = v
   }
+  def onError_=(handler: jfxsm.MediaErrorEvent => Unit) {
+    onError() = new jfxe.EventHandler[jfxsm.MediaErrorEvent] {
+      override def handle(event: jfxsm.MediaErrorEvent): Unit = handler(event)
+    }
+  }
 
   /**
    * Whether to preserve the aspect ratio (width / height) of the media when scaling it to fit the

--- a/scalafx/src/main/scala/scalafx/scene/media/MediaView.scala
+++ b/scalafx/src/main/scala/scalafx/scene/media/MediaView.scala
@@ -83,7 +83,7 @@ class MediaView(override val delegate: jfxsm.MediaView = new jfxsm.MediaView)
   def onError_=(v: jfxe.EventHandler[jfxsm.MediaErrorEvent]) {
     onError() = v
   }
-  def onError_=(handler: jfxsm.MediaErrorEvent => Unit) {
+  def onError_=(handler: MediaErrorEvent => Unit) {
     onError() = new jfxe.EventHandler[jfxsm.MediaErrorEvent] {
       override def handle(event: jfxsm.MediaErrorEvent): Unit = handler(event)
     }

--- a/scalafx/src/main/scala/scalafx/scene/transform/Transform.scala
+++ b/scalafx/src/main/scala/scalafx/scene/transform/Transform.scala
@@ -33,6 +33,7 @@ import scala.language.implicitConversions
 import scalafx.Includes._
 import scalafx.beans.property.{ObjectProperty, ReadOnlyBooleanProperty}
 import scalafx.delegate.SFXDelegate
+import scalafx.event.Event
 
 
 object Transform {
@@ -97,11 +98,12 @@ abstract class Transform(override val delegate: jfxst.Transform) extends SFXDele
   def onTransformChanged_=(v: jfxe.EventHandler[_ >: jfxst.TransformChangedEvent]) {
     ObjectProperty.fillProperty[jfxe.EventHandler[_ >: jfxst.TransformChangedEvent]](this.onTransformChanged, v)
   }
-  def onTransformChanged_=[T >: jfxst.TransformChangedEvent <: jfxe.Event](handler: T => Unit) {
+  def onTransformChanged_=[T >: TransformChangedEvent <: Event, U >: jfxst.TransformChangedEvent <: jfxe.Event](handler: T => Unit)
+                                                                                                               (implicit jfx2sfx: U => T) {
     ObjectProperty.fillProperty[jfxe.EventHandler[_ >: jfxst.TransformChangedEvent]](
       this.onTransformChanged,
-      new jfxe.EventHandler[T] {
-        override def handle(event: T): Unit = handler(event)
+      new jfxe.EventHandler[U] {
+        override def handle(event: U): Unit = handler(event)
       })
   }
 

--- a/scalafx/src/main/scala/scalafx/scene/transform/Transform.scala
+++ b/scalafx/src/main/scala/scalafx/scene/transform/Transform.scala
@@ -93,9 +93,9 @@ abstract class Transform(override val delegate: jfxst.Transform) extends SFXDele
   def identity: ReadOnlyBooleanProperty = delegate.identityProperty
 
   /** The onTransformChanged event handler is called whenever the transform changes any of its parameters. */
-  def onTransformChanged: ObjectProperty[jfxe.EventHandler[_ <: jfxst.TransformChangedEvent]] = delegate.onTransformChanged
-  def onTransformChanged_=(v: jfxe.EventHandler[_ <: jfxst.TransformChangedEvent]) {
-    ObjectProperty.fillProperty[jfxe.EventHandler[_ <: jfxst.TransformChangedEvent]](this.onTransformChanged, v)
+  def onTransformChanged: ObjectProperty[jfxe.EventHandler[_ >: jfxst.TransformChangedEvent]] = delegate.onTransformChanged
+  def onTransformChanged_=(v: jfxe.EventHandler[_ >: jfxst.TransformChangedEvent]) {
+    ObjectProperty.fillProperty[jfxe.EventHandler[_ >: jfxst.TransformChangedEvent]](this.onTransformChanged, v)
   }
 
   /** Determines if this is currently a 2D transform. */

--- a/scalafx/src/main/scala/scalafx/scene/transform/Transform.scala
+++ b/scalafx/src/main/scala/scalafx/scene/transform/Transform.scala
@@ -97,6 +97,13 @@ abstract class Transform(override val delegate: jfxst.Transform) extends SFXDele
   def onTransformChanged_=(v: jfxe.EventHandler[_ >: jfxst.TransformChangedEvent]) {
     ObjectProperty.fillProperty[jfxe.EventHandler[_ >: jfxst.TransformChangedEvent]](this.onTransformChanged, v)
   }
+  def onTransformChanged_=[T >: jfxst.TransformChangedEvent <: jfxe.Event](handler: T => Unit) {
+    ObjectProperty.fillProperty[jfxe.EventHandler[_ >: jfxst.TransformChangedEvent]](
+      this.onTransformChanged,
+      new jfxe.EventHandler[T] {
+        override def handle(event: T): Unit = handler(event)
+      })
+  }
 
   /** Determines if this is currently a 2D transform. */
   def type2D: ReadOnlyBooleanProperty = delegate.type2DProperty

--- a/scalafx/src/main/scala/scalafx/scene/web/WebEngine.scala
+++ b/scalafx/src/main/scala/scalafx/scene/web/WebEngine.scala
@@ -103,7 +103,7 @@ class WebEngine(override val delegate: jfxsw.WebEngine = new jfxsw.WebEngine)
   def onAlert_=(v: jfxe.EventHandler[jfxsw.WebEvent[String]]) {
     onAlert() = v
   }
-  def onAlert_=(handler: jfxsw.WebEvent[String] => Unit) {
+  def onAlert_=(handler: WebEvent[String] => Unit) {
     onAlert() = new jfxe.EventHandler[jfxsw.WebEvent[String]] {
       override def handle(event: jfxsw.WebEvent[String]): Unit = handler(event)
     }
@@ -118,7 +118,7 @@ class WebEngine(override val delegate: jfxsw.WebEngine = new jfxsw.WebEngine)
   def onError_=(v: jfxe.EventHandler[jfxsw.WebErrorEvent]) {
     onError() = v
   }
-  def onError_=(handler: jfxsw.WebErrorEvent => Unit) {
+  def onError_=(handler: WebErrorEvent => Unit) {
     onError() = new jfxe.EventHandler[jfxsw.WebErrorEvent] {
       override def handle(event: jfxsw.WebErrorEvent): Unit = handler(event)
     }
@@ -131,7 +131,7 @@ class WebEngine(override val delegate: jfxsw.WebEngine = new jfxsw.WebEngine)
   def onResized_=(v: jfxe.EventHandler[jfxsw.WebEvent[Rectangle2D]]) {
     onResized() = v
   }
-  def onResized_=(handler: jfxsw.WebEvent[Rectangle2D] => Unit): Unit = {
+  def onResized_=(handler: WebEvent[Rectangle2D] => Unit): Unit = {
     onResized() = new jfxe.EventHandler[jfxsw.WebEvent[Rectangle2D]] {
       override def handle(event: jfxsw.WebEvent[Rectangle2D]): Unit = handler(event)
     }
@@ -144,7 +144,7 @@ class WebEngine(override val delegate: jfxsw.WebEngine = new jfxsw.WebEngine)
   def onStatusChanged_=(v: jfxe.EventHandler[jfxsw.WebEvent[String]]) {
     onStatusChanged() = v
   }
-  def onStatusChanged_=(handler: jfxsw.WebEvent[String] => Unit) {
+  def onStatusChanged_=(handler: WebEvent[String] => Unit) {
     onStatusChanged() = new jfxe.EventHandler[jfxsw.WebEvent[String]] {
       override def handle(event: jfxsw.WebEvent[String]): Unit = handler(event)
     }
@@ -157,7 +157,7 @@ class WebEngine(override val delegate: jfxsw.WebEngine = new jfxsw.WebEngine)
   def onVisibilityChanged_=(v: jfxe.EventHandler[jfxsw.WebEvent[java.lang.Boolean]]) {
     onVisibilityChanged() = v
   }
-  def onVisibilityChanged_=(handler: jfxsw.WebEvent[java.lang.Boolean] => Unit) {
+  def onVisibilityChanged_=(handler: WebEvent[java.lang.Boolean] => Unit) {
     onVisibilityChanged() = new jfxe.EventHandler[jfxsw.WebEvent[java.lang.Boolean]] {
       override def handle(event: jfxsw.WebEvent[java.lang.Boolean]): Unit = handler(event)
     }

--- a/scalafx/src/main/scala/scalafx/scene/web/WebEngine.scala
+++ b/scalafx/src/main/scala/scalafx/scene/web/WebEngine.scala
@@ -103,6 +103,11 @@ class WebEngine(override val delegate: jfxsw.WebEngine = new jfxsw.WebEngine)
   def onAlert_=(v: jfxe.EventHandler[jfxsw.WebEvent[String]]) {
     onAlert() = v
   }
+  def onAlert_=(handler: jfxsw.WebEvent[String] => Unit) {
+    onAlert() = new jfxe.EventHandler[jfxsw.WebEvent[String]] {
+      override def handle(event: jfxsw.WebEvent[String]): Unit = handler(event)
+    }
+  }
 
   /**
    * The event handler called when an error occurs.
@@ -113,6 +118,11 @@ class WebEngine(override val delegate: jfxsw.WebEngine = new jfxsw.WebEngine)
   def onError_=(v: jfxe.EventHandler[jfxsw.WebErrorEvent]) {
     onError() = v
   }
+  def onError_=(handler: jfxsw.WebErrorEvent => Unit) {
+    onError() = new jfxe.EventHandler[jfxsw.WebErrorEvent] {
+      override def handle(event: jfxsw.WebErrorEvent): Unit = handler(event)
+    }
+  }
 
   /**
    * JavaScript window resize handler property.
@@ -120,6 +130,11 @@ class WebEngine(override val delegate: jfxsw.WebEngine = new jfxsw.WebEngine)
   def onResized = delegate.onResizedProperty
   def onResized_=(v: jfxe.EventHandler[jfxsw.WebEvent[Rectangle2D]]) {
     onResized() = v
+  }
+  def onResized_=(handler: jfxsw.WebEvent[Rectangle2D] => Unit): Unit = {
+    onResized() = new jfxe.EventHandler[jfxsw.WebEvent[Rectangle2D]] {
+      override def handle(event: jfxsw.WebEvent[Rectangle2D]): Unit = handler(event)
+    }
   }
 
   /**
@@ -129,6 +144,11 @@ class WebEngine(override val delegate: jfxsw.WebEngine = new jfxsw.WebEngine)
   def onStatusChanged_=(v: jfxe.EventHandler[jfxsw.WebEvent[String]]) {
     onStatusChanged() = v
   }
+  def onStatusChanged_=(handler: jfxsw.WebEvent[String] => Unit) {
+    onStatusChanged() = new jfxe.EventHandler[jfxsw.WebEvent[String]] {
+      override def handle(event: jfxsw.WebEvent[String]): Unit = handler(event)
+    }
+  }
 
   /**
    * JavaScript window visibility handler property.
@@ -136,6 +156,11 @@ class WebEngine(override val delegate: jfxsw.WebEngine = new jfxsw.WebEngine)
   def onVisibilityChanged = delegate.onVisibilityChangedProperty
   def onVisibilityChanged_=(v: jfxe.EventHandler[jfxsw.WebEvent[java.lang.Boolean]]) {
     onVisibilityChanged() = v
+  }
+  def onVisibilityChanged_=(handler: jfxsw.WebEvent[java.lang.Boolean] => Unit) {
+    onVisibilityChanged() = new jfxe.EventHandler[jfxsw.WebEvent[java.lang.Boolean]] {
+      override def handle(event: jfxsw.WebEvent[java.lang.Boolean]): Unit = handler(event)
+    }
   }
 
   /**

--- a/scalafx/src/main/scala/scalafx/scene/web/WebView.scala
+++ b/scalafx/src/main/scala/scalafx/scene/web/WebView.scala
@@ -46,7 +46,7 @@ object WebView {
   /**
    * Converts a ScalaFX WebView to its JavaFX counterpart.
    *
-   * @param we ScalaFX WebView
+   * @param wv ScalaFX WebView
    * @return JavaFX WebView
    */
   implicit def sfxWebView2jfx(wv: WebView): jfxsw.WebView = if (wv != null) wv.delegate else null

--- a/scalafx/src/main/scala/scalafx/scene/web/WebView.scala
+++ b/scalafx/src/main/scala/scalafx/scene/web/WebView.scala
@@ -169,6 +169,12 @@ class WebView(override val delegate: jfxsw.WebView = new jfxsw.WebView)
   def onAlert_=(v: jfxe.EventHandler[jfxsw.WebEvent[String]]) {
     delegate.engine.onAlert = v
   }
+  def onAlert_=(handler: jfxsw.WebEvent[String] => Unit) {
+    delegate.engine.onAlert = new jfxe.EventHandler[jfxsw.WebEvent[String]] {
+      override def handle(event: jfxsw.WebEvent[String]): Unit = handler(event)
+    }
+  }
+
 
   /**
    * JavaScript window resize handler property.
@@ -176,6 +182,11 @@ class WebView(override val delegate: jfxsw.WebView = new jfxsw.WebView)
   def onResized = delegate.engine.onResized
   def onResized_=(v: jfxe.EventHandler[jfxsw.WebEvent[jfxg.Rectangle2D]]) {
     delegate.engine.onResized = v
+  }
+  def onResized_=(handler: jfxsw.WebEvent[jfxg.Rectangle2D] => Unit): Unit = {
+    delegate.engine.onResized = new jfxe.EventHandler[jfxsw.WebEvent[jfxg.Rectangle2D]] {
+      override def handle(event: jfxsw.WebEvent[jfxg.Rectangle2D]): Unit = handler(event)
+    }
   }
 
   /**
@@ -185,6 +196,11 @@ class WebView(override val delegate: jfxsw.WebView = new jfxsw.WebView)
   def onStatusChanged_=(v: jfxe.EventHandler[jfxsw.WebEvent[String]]) {
     delegate.engine.onStatusChanged = v
   }
+  def onStatusChanged_=(handler: jfxsw.WebEvent[String] => Unit) {
+    delegate.engine.onStatusChanged = new jfxe.EventHandler[jfxsw.WebEvent[String]] {
+      override def handle(event: jfxsw.WebEvent[String]): Unit = handler(event)
+    }
+  }
 
   /**
    * JavaScript window visibility handler property.
@@ -192,6 +208,11 @@ class WebView(override val delegate: jfxsw.WebView = new jfxsw.WebView)
   def onVisibilityChanged = delegate.engine.onVisibilityChanged
   def onVisibilityChanged_=(v: jfxe.EventHandler[jfxsw.WebEvent[java.lang.Boolean]]) {
     delegate.engine.onVisibilityChanged = v
+  }
+  def onVisibilityChanged_=(handler: jfxsw.WebEvent[java.lang.Boolean] => Unit) {
+    delegate.engine.onVisibilityChanged = new jfxe.EventHandler[jfxsw.WebEvent[java.lang.Boolean]] {
+      override def handle(event: jfxsw.WebEvent[java.lang.Boolean]): Unit = handler(event)
+    }
   }
 
   /**

--- a/scalafx/src/main/scala/scalafx/scene/web/WebView.scala
+++ b/scalafx/src/main/scala/scalafx/scene/web/WebView.scala
@@ -169,7 +169,7 @@ class WebView(override val delegate: jfxsw.WebView = new jfxsw.WebView)
   def onAlert_=(v: jfxe.EventHandler[jfxsw.WebEvent[String]]) {
     delegate.engine.onAlert = v
   }
-  def onAlert_=(handler: jfxsw.WebEvent[String] => Unit) {
+  def onAlert_=(handler: WebEvent[String] => Unit) {
     delegate.engine.onAlert = new jfxe.EventHandler[jfxsw.WebEvent[String]] {
       override def handle(event: jfxsw.WebEvent[String]): Unit = handler(event)
     }
@@ -183,7 +183,7 @@ class WebView(override val delegate: jfxsw.WebView = new jfxsw.WebView)
   def onResized_=(v: jfxe.EventHandler[jfxsw.WebEvent[jfxg.Rectangle2D]]) {
     delegate.engine.onResized = v
   }
-  def onResized_=(handler: jfxsw.WebEvent[jfxg.Rectangle2D] => Unit): Unit = {
+  def onResized_=(handler: WebEvent[jfxg.Rectangle2D] => Unit): Unit = {
     delegate.engine.onResized = new jfxe.EventHandler[jfxsw.WebEvent[jfxg.Rectangle2D]] {
       override def handle(event: jfxsw.WebEvent[jfxg.Rectangle2D]): Unit = handler(event)
     }
@@ -196,7 +196,7 @@ class WebView(override val delegate: jfxsw.WebView = new jfxsw.WebView)
   def onStatusChanged_=(v: jfxe.EventHandler[jfxsw.WebEvent[String]]) {
     delegate.engine.onStatusChanged = v
   }
-  def onStatusChanged_=(handler: jfxsw.WebEvent[String] => Unit) {
+  def onStatusChanged_=(handler: WebEvent[String] => Unit) {
     delegate.engine.onStatusChanged = new jfxe.EventHandler[jfxsw.WebEvent[String]] {
       override def handle(event: jfxsw.WebEvent[String]): Unit = handler(event)
     }
@@ -209,7 +209,7 @@ class WebView(override val delegate: jfxsw.WebView = new jfxsw.WebView)
   def onVisibilityChanged_=(v: jfxe.EventHandler[jfxsw.WebEvent[java.lang.Boolean]]) {
     delegate.engine.onVisibilityChanged = v
   }
-  def onVisibilityChanged_=(handler: jfxsw.WebEvent[java.lang.Boolean] => Unit) {
+  def onVisibilityChanged_=(handler: WebEvent[java.lang.Boolean] => Unit) {
     delegate.engine.onVisibilityChanged = new jfxe.EventHandler[jfxsw.WebEvent[java.lang.Boolean]] {
       override def handle(event: jfxsw.WebEvent[java.lang.Boolean]): Unit = handler(event)
     }

--- a/scalafx/src/main/scala/scalafx/stage/PopupWindow.scala
+++ b/scalafx/src/main/scala/scalafx/stage/PopupWindow.scala
@@ -32,6 +32,7 @@ import scala.language.implicitConversions
 import scalafx.Includes._
 import scalafx.beans.property._
 import scalafx.delegate.{SFXDelegate, SFXEnumDelegate, SFXEnumDelegateCompanion}
+import scalafx.event.Event
 import scalafx.scene.Node
 import scalafx.scene.Node._
 import scalafx.stage.Window._
@@ -130,7 +131,7 @@ abstract class PopupWindow(override val delegate: jfxs.PopupWindow)
   def onAutoHide_=(v: jfxe.EventHandler[jfxe.Event]) {
     onAutoHide() = v
   }
-  def onAutoHide_=(handler: jfxe.Event => Unit) {
+  def onAutoHide_=(handler: Event => Unit) {
     onAutoHide() = new jfxe.EventHandler[jfxe.Event] {
       override def handle(event: jfxe.Event): Unit = handler(event)
     }

--- a/scalafx/src/main/scala/scalafx/stage/PopupWindow.scala
+++ b/scalafx/src/main/scala/scalafx/stage/PopupWindow.scala
@@ -130,6 +130,11 @@ abstract class PopupWindow(override val delegate: jfxs.PopupWindow)
   def onAutoHide_=(v: jfxe.EventHandler[jfxe.Event]) {
     onAutoHide() = v
   }
+  def onAutoHide_=(handler: jfxe.Event => Unit) {
+    onAutoHide() = new jfxe.EventHandler[jfxe.Event] {
+      override def handle(event: jfxe.Event): Unit = handler(event)
+    }
+  }
 
   /**
    * The window which is the parent of this popup.

--- a/scalafx/src/main/scala/scalafx/stage/PopupWindow.scala
+++ b/scalafx/src/main/scala/scalafx/stage/PopupWindow.scala
@@ -173,7 +173,7 @@ abstract class PopupWindow(override val delegate: jfxs.PopupWindow)
    * @since 2.2
    */
   def consumeAutoHidingEvents: BooleanProperty = delegate.consumeAutoHidingEventsProperty
-  def consumeAutoHidingEvents(v: Boolean) {
+  def consumeAutoHidingEvents_=(v: Boolean) {
     consumeAutoHidingEvents() = v
   }
 

--- a/scalafx/src/main/scala/scalafx/stage/Window.scala
+++ b/scalafx/src/main/scala/scalafx/stage/Window.scala
@@ -71,7 +71,7 @@ class Window protected(override val delegate: jfxs.Window)
   def onCloseRequest_=(v: jfxe.EventHandler[jfxs.WindowEvent]) {
     onCloseRequest() = v
   }
-  def onCloseRequest_=(handler: jfxs.WindowEvent => Unit) {
+  def onCloseRequest_=(handler: WindowEvent => Unit) {
     onCloseRequest() = new jfxe.EventHandler[jfxs.WindowEvent] {
       override def handle(event: jfxs.WindowEvent): Unit = handler(event)
     }
@@ -84,7 +84,7 @@ class Window protected(override val delegate: jfxs.Window)
   def onHidden_=(v: jfxe.EventHandler[jfxs.WindowEvent]) {
     onHidden() = v
   }
-  def onHidden_=(handler: jfxs.WindowEvent => Unit) {
+  def onHidden_=(handler: WindowEvent => Unit) {
     onHidden() = new jfxe.EventHandler[jfxs.WindowEvent] {
       override def handle(event: jfxs.WindowEvent): Unit = handler(event)
     }
@@ -97,7 +97,7 @@ class Window protected(override val delegate: jfxs.Window)
   def onHiding_=(v: jfxe.EventHandler[jfxs.WindowEvent]) {
     onHiding() = v
   }
-  def onHiding_=(handler: jfxs.WindowEvent => Unit) {
+  def onHiding_=(handler: WindowEvent => Unit) {
     onHiding() = new jfxe.EventHandler[jfxs.WindowEvent] {
       override def handle(event: jfxs.WindowEvent): Unit = handler(event)
     }
@@ -110,7 +110,7 @@ class Window protected(override val delegate: jfxs.Window)
   def onShowing_=(v: jfxe.EventHandler[jfxs.WindowEvent]) {
     onShowing() = v
   }
-  def onShowing_=(handler: jfxs.WindowEvent => Unit) {
+  def onShowing_=(handler: WindowEvent => Unit) {
     onShowing() = new jfxe.EventHandler[jfxs.WindowEvent] {
       override def handle(event: jfxs.WindowEvent): Unit = handler(event)
     }
@@ -123,7 +123,7 @@ class Window protected(override val delegate: jfxs.Window)
   def onShown_=(v: jfxe.EventHandler[jfxs.WindowEvent]) {
     onShown() = v
   }
-  def onShown_=(handler: jfxs.WindowEvent => Unit) {
+  def onShown_=(handler: WindowEvent => Unit) {
     onShown() = new jfxe.EventHandler[jfxs.WindowEvent] {
       override def handle(event: jfxs.WindowEvent): Unit = handler(event)
     }

--- a/scalafx/src/main/scala/scalafx/stage/Window.scala
+++ b/scalafx/src/main/scala/scalafx/stage/Window.scala
@@ -71,6 +71,11 @@ class Window protected(override val delegate: jfxs.Window)
   def onCloseRequest_=(v: jfxe.EventHandler[jfxs.WindowEvent]) {
     onCloseRequest() = v
   }
+  def onCloseRequest_=(handler: jfxs.WindowEvent => Unit) {
+    onCloseRequest() = new jfxe.EventHandler[jfxs.WindowEvent] {
+      override def handle(event: jfxs.WindowEvent): Unit = handler(event)
+    }
+  }
 
   /**
    * Called just after the Window has been hidden.
@@ -78,6 +83,11 @@ class Window protected(override val delegate: jfxs.Window)
   def onHidden = delegate.onHiddenProperty
   def onHidden_=(v: jfxe.EventHandler[jfxs.WindowEvent]) {
     onHidden() = v
+  }
+  def onHidden_=(handler: jfxs.WindowEvent => Unit) {
+    onHidden() = new jfxe.EventHandler[jfxs.WindowEvent] {
+      override def handle(event: jfxs.WindowEvent): Unit = handler(event)
+    }
   }
 
   /**
@@ -87,6 +97,11 @@ class Window protected(override val delegate: jfxs.Window)
   def onHiding_=(v: jfxe.EventHandler[jfxs.WindowEvent]) {
     onHiding() = v
   }
+  def onHiding_=(handler: jfxs.WindowEvent => Unit) {
+    onHiding() = new jfxe.EventHandler[jfxs.WindowEvent] {
+      override def handle(event: jfxs.WindowEvent): Unit = handler(event)
+    }
+  }
 
   /**
    * Called just prior to the Window being shown, even if the menu has no items to show.
@@ -95,6 +110,11 @@ class Window protected(override val delegate: jfxs.Window)
   def onShowing_=(v: jfxe.EventHandler[jfxs.WindowEvent]) {
     onShowing() = v
   }
+  def onShowing_=(handler: jfxs.WindowEvent => Unit) {
+    onShowing() = new jfxe.EventHandler[jfxs.WindowEvent] {
+      override def handle(event: jfxs.WindowEvent): Unit = handler(event)
+    }
+  }
 
   /**
    * Called just after the Window is shown.
@@ -102,6 +122,11 @@ class Window protected(override val delegate: jfxs.Window)
   def onShown = delegate.onShownProperty
   def onShown_=(v: jfxe.EventHandler[jfxs.WindowEvent]) {
     onShown() = v
+  }
+  def onShown_=(handler: jfxs.WindowEvent => Unit) {
+    onShown() = new jfxe.EventHandler[jfxs.WindowEvent] {
+      override def handle(event: jfxs.WindowEvent): Unit = handler(event)
+    }
   }
 
   /**

--- a/scalafx/src/test/scala/issues/issue102/IncompleteClickHandler.scala
+++ b/scalafx/src/test/scala/issues/issue102/IncompleteClickHandler.scala
@@ -29,6 +29,7 @@ package issues.issue102
 
 import scalafx.Includes._
 import scalafx.application.JFXApp
+import scalafx.event.ActionEvent
 import scalafx.geometry.Insets
 import scalafx.scene.Scene
 import scalafx.scene.control.{Button, Label}
@@ -121,7 +122,7 @@ object IncompleteClickHandler extends JFXApp {
             },
             new Button {
               text = "Button 6: New fine approach using `handle {}`"
-              onAction = handle {
+              onAction = { actionEvent: ActionEvent =>
                 println("Button 6 - Message 1")
                 println("Button 6 - Message 2")
               }

--- a/scalafx/src/test/scala/issues/issue178/MultipleFileChooserDemo.scala
+++ b/scalafx/src/test/scala/issues/issue178/MultipleFileChooserDemo.scala
@@ -31,6 +31,7 @@ import scala.language.implicitConversions
 import scalafx.Includes._
 import scalafx.application.JFXApp
 import scalafx.application.JFXApp.PrimaryStage
+import scalafx.event.ActionEvent
 import scalafx.geometry.Insets
 import scalafx.scene.Scene
 import scalafx.scene.control.Button
@@ -51,7 +52,7 @@ object MultipleFileChooserDemo extends JFXApp {
         padding = Insets(12)
         children = new Button {
           text = "Open file chooser and select multiple files or Cancel"
-          onAction = handle {
+          onAction = { actionEvent: ActionEvent =>
             val fc = new FileChooser()
             val selection = fc.showOpenMultipleDialog(stage)
 


### PR DESCRIPTION
This fixes #194. Also, along the way, I've correct some typos related to the lambda assignment.

This, however, seems to break anything using the `handle` function. `handle` seems to be returning a lot of `EventHandler[Nothing]` which type errors when applied against anything that expects an `EventHandler[(not Nothing)]` or a lambda.

Example:

```
scalafx-demos/src/main/scala/scalafx/VanishingCircles.scala:64: overloaded method value onMouseClicked_= with alternatives:
[error]   [T >: javafx.scene.input.MouseEvent <: javafx.event.Event](handler: T => Unit)Unit <and>
[error]   (v: javafx.event.EventHandler[_ >: javafx.scene.input.MouseEvent])Unit
[error]  cannot be applied to (javafx.event.EventHandler[Nothing])
[error]         onMouseClicked = handle {
[error]         ^
```
