### PR TITLE
Fixed issue #69.

### DIFF
--- a/scalafx-demos/src/main/scala/scalafx/ColorfulCircles.scala
+++ b/scalafx-demos/src/main/scala/scalafx/ColorfulCircles.scala
@@ -50,19 +50,29 @@ import scalafx.scene.{Group, Scene}
  */
 object ColorfulCircles extends JFXApp {
   val circlesToAnimate = new VectorBuilder[Circle]()
+  val initWidth = 800
+  val initHeight = 600
   stage = new PrimaryStage {
-    width = 800
-    height = 600
+    width = initWidth
+    height = initHeight
+    val rectA = new Rectangle {
+      width = initWidth
+      height = initHeight
+      fill = Black
+    }
+    val rectB = new Rectangle {
+      width = initWidth
+      height = initHeight
+      fill = new LinearGradient(0, 1, 1, 0, true, NoCycle,
+      Stops(0xf8bd55, 0xc0fe56, 0x5dfbc1, 0x64c2f8, 0xbe4af7, 0xed5fc2, 0xef504c, 0xf2660f))
+      blendMode = Overlay
+    }
     scene = new Scene {
       fill = Black
       content = Seq(
         new Group {
           children = Seq(
-            new Rectangle {
-              width <== scene.width
-              height <== scene.height
-              fill = Black
-            },
+            rectA,
             new Group {
               val circles = for (i <- 0 until 15) yield new Circle {
                 radius = 200
@@ -100,27 +110,26 @@ object ColorfulCircles extends JFXApp {
               effect = new BoxBlur(10, 10, 3)
             })
         },
-        new Rectangle {
-          width <== scene.width
-          height <== scene.height
-          fill = new LinearGradient(0, 1, 1, 0, true, NoCycle,
-            Stops(0xf8bd55, 0xc0fe56, 0x5dfbc1, 0x64c2f8, 0xbe4af7, 0xed5fc2, 0xef504c, 0xf2660f))
-          blendMode = Overlay
-        }
+        rectB
       )
     }
+    // Have the two rectangles react to changes in scene height & width
+    rectA.width <== scene.width
+    rectA.height <== scene.height
+    rectB.width <== scene.width
+    rectB.height <== scene.height
   }
   new Timeline {
     cycleCount = Indefinite
     autoReverse = true
     keyFrames = (for (circle <- circlesToAnimate.result()) yield Seq(
       at(0 s) {
-        Set(circle.centerX -> random * 800,
-          circle.centerY -> random * 600)
+        Set(circle.centerX -> random * initWidth,
+          circle.centerY -> random * initHeight)
       },
       at(40 s) {
-        Set(circle.centerX -> random * 800,
-          circle.centerY -> random * 600)
+        Set(circle.centerX -> random * initWidth,
+          circle.centerY -> random * initHeight)
       }
     )).flatten
   }.play()

--- a/scalafx-demos/src/main/scala/scalafx/SimpleColorfulCircles.scala
+++ b/scalafx-demos/src/main/scala/scalafx/SimpleColorfulCircles.scala
@@ -49,14 +49,23 @@ import scalafx.scene.shape.{Circle, Rectangle}
  */
 object SimpleColorfulCircles extends JFXApp {
   var circles: Seq[Circle] = null
+  val initWidth = 800
+  val initHeight = 600
   stage = new PrimaryStage {
-    width = 800
-    height = 600
+    width = initWidth
+    height = initHeight
+    val rect = new Rectangle {
+      width = initWidth
+      height = initHeight
+      fill = new LinearGradient(0, 1, 1, 0, true, NoCycle,
+      Stops(0xf8bd55, 0xc0fe56, 0x5dfbc1, 0x64c2f8, 0xbe4af7, 0xed5fc2, 0xef504c, 0xf2660f))
+      blendMode = Overlay
+    }
     scene = new Scene {
       fill = Black
       circles = for (i <- 0 until 30) yield new Circle {
-        centerX = random * 800
-        centerY = random * 600
+        centerX = random * initWidth
+        centerY = random * initHeight
         radius = 150
         fill = White opacity 0.05
         stroke = White opacity 0.16
@@ -64,14 +73,11 @@ object SimpleColorfulCircles extends JFXApp {
         strokeType = Outside
         effect = new BoxBlur(10, 10, 3)
       }
-      content = circles :+ new Rectangle {
-        width <== scene.width
-        height <== scene.height
-        fill = new LinearGradient(0, 1, 1, 0, true, NoCycle,
-          Stops(0xf8bd55, 0xc0fe56, 0x5dfbc1, 0x64c2f8, 0xbe4af7, 0xed5fc2, 0xef504c, 0xf2660f))
-        blendMode = Overlay
-      }
+      content = circles :+ rect
     }
+    // Have rectangle react to changes in scene height & width
+    rect.width <== scene.width
+    rect.height <== scene.height
   }
   new Timeline {
     cycleCount = Indefinite

--- a/scalafx/src/main/scala/scalafx/application/JFXApp.scala
+++ b/scalafx/src/main/scala/scalafx/application/JFXApp.scala
@@ -215,24 +215,25 @@ trait JFXApp extends DelayedInit {
    */
   protected lazy val parameters: Parameters = Parameters(arguments)
 
-  /* Add class/object construction/initialization code to the code execution buffer.
-   *
-   * This function is called multiple times (by the Scala compiler) with the initialization/construction code of each
-   * class and object (but not trait!) that extends JFXApp. This code is buffered until it can be executed in main().
-   *
-   * @note I (Mike Allen) think there's a good case for making this final, to prevent user code from destroying the
-   * application initialization logic.
-   */
+  /** Add class/object construction/initialization code to the code execution buffer.
+    *
+    * This function is called multiple times (by the Scala compiler) within the initialization/construction code of
+    * each class and object (but not trait!) that extends JFXApp. This code is buffered until it can be executed in
+    * main().
+    *
+    * @note You are strongly advised not to override this function.
+    */
   def delayedInit(x: => Unit) {
     subClassInitCode += (() => x)
   }
 
-  /* Perform app-related initialization, and execute initialization/construction code for all classes and object that
-   * extend this trait.
-   *
-   * @note I (Mike Allen) think there's a good case for making this final, to prevent user code from destroying the
-   * application initialization logic.
-   */
+  /** Perform app-related initialization, and execute initialization/construction code for all classes and objects that
+    * extend this trait.
+    *
+    * @note You are strongly advised not to override this function.
+    *
+    * @param args Command line arguments.
+    */
   def main(args: Array[String]) {
     JFXApp.ACTIVE_APP = this
     arguments = args

--- a/scalafx/src/main/scala/scalafx/application/JFXApp.scala
+++ b/scalafx/src/main/scala/scalafx/application/JFXApp.scala
@@ -217,11 +217,12 @@ trait JFXApp extends DelayedInit {
 
   /** Add class/object construction/initialization code to the code execution buffer.
     *
-    * This function is called multiple times (by the Scala compiler) within the initialization/construction code of
-    * each class and object (but not trait!) that extends JFXApp. This code is buffered until it can be executed in
-    * main().
+    * This function is called multiple times (by the Scala compiler) with the initialization/construction code of each
+    * class and object (but not trait!) that extends JFXApp. This code is buffered until it can be executed in main().
     *
     * @note You are strongly advised not to override this function.
+    *
+    * @param x Class/object construction code to be buffered for delayed execution.
     */
   def delayedInit(x: => Unit) {
     subClassInitCode += (() => x)


### PR DESCRIPTION
Both the `ColorfulCircles` and `SimpleColorfulCircles` demos now work as they should.

When I originally investigated this problem, I couldn't figure out how the rectangles in these demos were supposed to get their width & height, when the scene they were obtaining them from had yet to be constructed. I reasoned that I could initialize the stage/scene and rectangles to be set to an initial height & width (and, co-incidentally, made the starting X & Y co-ordinates of the circles use the same values), then - after the scene had been constructed - have the rectangles update their width & height if the scene's width & height changed. This did the trick, and the demos now work as expected.

I don't think it's legal to refer to an object during its construction in the way that these demos did - and I have no idea why or how they worked in ScalaFX 2.