### PR TITLE
Fix method name

### DIFF
--- a/scalafx/src/main/scala/scalafx/stage/Stage.scala
+++ b/scalafx/src/main/scala/scalafx/stage/Stage.scala
@@ -86,7 +86,7 @@ class Stage(override val delegate: jfxs.Stage = new jfxs.Stage)
    * Specifies the Full Screen exit key combination
    */
   def fullScreenExitKey: ObjectProperty[jfxsi.KeyCombination] = delegate.fullScreenExitKeyProperty
-  def fullScreenExitHint_=(value: KeyCombination) {
+  def fullScreenExitKey_=(value: KeyCombination) {
     fullScreenExitKey() = value
   }
 


### PR DESCRIPTION
Method which changes full screen exit key was named 'fullScreenExitHint_=' instead 'fullScreenExitKey_='.

I fixed it. Sbt compile and Sbt test do not show any errors.
It is my first contribution to scalafx :)