### PR TITLE
Fix TextFieldListCell.converter_=(c) method

### DIFF
--- a/scalafx/src/main/scala/scalafx/scene/control/cell/package.scala
+++ b/scalafx/src/main/scala/scalafx/scene/control/cell/package.scala
@@ -65,7 +65,7 @@ package object cell {
     /**
      * The `StringConverter` property.
      */
-    def converter: ObjectProperty[StringConverter[J]] = ObjectProperty(delegate.converterProperty().getValue)
+    def converter: ObjectProperty[jfxu.StringConverter[J]] = delegate.converterProperty()
     def converter_=(v: StringConverter[J]) {
       converter() = v
     }

--- a/scalafx/src/test/scala/issues/issue262/Issue262Spec.scala
+++ b/scalafx/src/test/scala/issues/issue262/Issue262Spec.scala
@@ -1,0 +1,21 @@
+package issues.issue262
+
+import javafx.util.converter.IntegerStringConverter
+
+import org.junit.runner.RunWith
+import org.scalatest.FlatSpec
+import org.scalatest.Matchers._
+import org.scalatest.junit.JUnitRunner
+
+import scalafx.Includes._
+import scalafx.scene.control.cell.TextFieldListCell
+import scalafx.testutil.RunOnApplicationThread
+
+@RunWith(classOf[JUnitRunner])
+class Issue262Spec extends FlatSpec with RunOnApplicationThread {
+  "TextFieldListCell" should "support changing of StringConverter" in {
+    val cell = new TextFieldListCell[Integer]
+    cell.converter = new IntegerStringConverter
+    cell.converter.value.fromString("123") should be(123)
+  }
+}


### PR DESCRIPTION
Fixes #262. The `converter()` method of the `ConvertableCell` trait
was creating a fresh ScalaFX `ObjectProperty` out of the **value**
of underlying `converterProperty()`. While it is OK when reading the
converter value, it didn't work for **setting** new converter through
this wrapper from ScalaFX (this can still be achieved through the
`delegate.setConverter(c)`).

This commit changes the `converter()` method to return a wrapper
for the underlying **property** instead of value.

**Warning:** This change technically can break some existing code, though,
since it changes the type of the `converter()` method.