### PR TITLE
Fixed #269: '+' not working as expected on StringExpression.

### DIFF
--- a/scalafx/src/main/scala/scalafx/beans/binding/StringExpression.scala
+++ b/scalafx/src/main/scala/scalafx/beans/binding/StringExpression.scala
@@ -71,16 +71,13 @@ class StringExpression(val delegate: jfxbb.StringExpression) {
   def >=(v: ObservableStringValue) = delegate.greaterThanOrEqualTo(v)
 
   // Kind of an odd case that concat is not observable, but this is how it is coded in JavaFX
-  def +(v: Null) = delegate.concat(v.asInstanceOf[String])
-  def +(v: ObservableStringValue) = delegate.concat(v)
-  def +(v: Any) = delegate.concat(v)
+  def + = concat _
 
-  def concat(v: Object) = {
+  def concat(v: Any) = {
     val jfxV = v match {
       case d: SFXDelegate[_] => d.delegate
       case a => a
     }
-    delegate.concat(jfxV)
+    new StringExpression(delegate.concat(jfxV))
   }
-
 }

--- a/scalafx/src/test/scala/scalafx/beans/property/StringPropertySpec.scala
+++ b/scalafx/src/test/scala/scalafx/beans/property/StringPropertySpec.scala
@@ -27,12 +27,8 @@
 
 package scalafx.beans.property
 
-import javafx.beans.{property => jfxbp}
-
 import org.scalatest.Matchers._
 import org.scalatest.{BeforeAndAfterEach, FlatSpec}
-
-import scalafx.Includes._
 
 /**
  * StringProperty Spec tests.
@@ -41,10 +37,10 @@ import scalafx.Includes._
  */
 class StringPropertySpec extends FlatSpec with BeforeAndAfterEach {
   val bean = new Object()
-  var booleanProperty: jfxbp.BooleanProperty = null
-  var stringProperty: jfxbp.StringProperty = null
-  var stringProperty2: jfxbp.StringProperty = null
-  var stringProperty3: jfxbp.StringProperty = null
+  var booleanProperty: BooleanProperty = null
+  var stringProperty: StringProperty = null
+  var stringProperty2: StringProperty = null
+  var stringProperty3: StringProperty = null
   var sfxStringProperty: StringProperty = null
 
   override def beforeEach() {


### PR DESCRIPTION
Changed the '+' method to use the 'concat' method.
Changed 'concat' to return a ScalaFX StringExpression rather than JafaFX StringExpression.
   - This is more in line with how '+' works on NumberExpression.

Changed the unit tests to expose the behavior described in issue #269.
This was done by eliminated implicit conversions.