### PR TITLE
[RFC] build: use mill to build ScalaFX

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -1,0 +1,31 @@
+import mill._, scalalib._
+import $ivy.`com.lihaoyi::mill-contrib-bloop:0.5.0`
+
+// JavaFX options
+val javaFXVersion = "12.0.1"
+val scalafxVersion = s"$javaFXVersion-R18-SNAPSHOT"
+
+object scalafx extends mill.Cross[ScalaFXCrossModule]("2.13.0", "2.12.9", "2.11.12")
+
+class ScalaFXCrossModule(val crossScalaVersion: String) extends CrossSbtModule { parent =>
+  def suffix = crossScalaVersion
+  def millSourcePath = os.pwd / "scalafx"
+
+  def scalacOptions = Seq("-unchecked", "-deprecation", "-Xcheckinit", "-encoding", "utf8", "-feature")
+  def ivyDeps =
+    Agg(ivy"org.scala-lang:scala-reflect:$crossScalaVersion") ++
+      Seq("base", "controls", "fxml", "graphics", "media", "swing", "web").map(m =>
+        ivy"org.openjfx:javafx-$m:$javaFXVersion")
+
+  object test extends Tests {
+    def ivyDeps = Agg(ivy"org.scalatest::scalatest:3.0.8")
+    def testFrameworks = Seq("org.scalatest.tools.Framework")
+  }
+
+  object demos extends SbtModule {
+    def scalaVersion = crossScalaVersion
+    def millSourcePath = os.pwd / "scalafx-demos"
+    def moduleDeps = Seq(parent)
+  }
+}
+

--- a/mill
+++ b/mill
@@ -1,0 +1,37 @@
+#!/usr/bin/env sh
+
+# This is a wrapper script, that automatically download mill from GitHub release pages
+# You can give the required mill version with MILL_VERSION env variable
+# If no version is given, it falls back to the value of DEFAULT_MILL_VERSION
+DEFAULT_MILL_VERSION=0.5.0
+
+set -e
+
+if [ -z "$MILL_VERSION" ] ; then
+  if [ -f ".mill-version" ] ; then
+    MILL_VERSION="$(head -n 1 .mill-version 2> /dev/null)"
+  elif [ -f "mill" ] && [ "$BASH_SOURCE" != "mill" ] ; then
+    MILL_VERSION=$(grep -F "DEFAULT_MILL_VERSION=" "mill" | head -n 1 | cut -d= -f2)
+  else
+    MILL_VERSION=$DEFAULT_MILL_VERSION
+  fi
+fi
+
+MILL_DOWNLOAD_PATH="$HOME/.mill/download"
+MILL_EXEC_PATH="${MILL_DOWNLOAD_PATH}/$MILL_VERSION"
+
+if [ ! -x "$MILL_EXEC_PATH" ] ; then
+  mkdir -p $MILL_DOWNLOAD_PATH
+  DOWNLOAD_FILE=$MILL_EXEC_PATH-tmp-download
+  MILL_DOWNLOAD_URL="https://github.com/lihaoyi/mill/releases/download/${MILL_VERSION%%-*}/$MILL_VERSION-assembly"
+  curl --fail -L -o "$DOWNLOAD_FILE" "$MILL_DOWNLOAD_URL"
+  chmod +x "$DOWNLOAD_FILE"
+  mv "$DOWNLOAD_FILE" "$MILL_EXEC_PATH"
+  unset DOWNLOAD_FILE
+  unset MILL_DOWNLOAD_URL
+fi
+
+unset MILL_DOWNLOAD_PATH
+unset MILL_VERSION
+
+exec $MILL_EXEC_PATH "$@"


### PR DESCRIPTION
 - building can now be done as:
    ./mill scalafx[2.13.0].compile
    ./mill scalafx[2.13.0].demos.run
    ./mill scalafx[2.13.0].test
   or distributed as:
    ./mill scalafx[2.13.0].assembly

- this also comes with bloop support:
    ./mill mill.contrib.Bloop/install
  which can then improve compile/test times
    bloop test scalafx\[2.13.0\]

Note: this doesn't provide all the features of the previous sbt build definition (yet?)