### PR TITLE
style: remove now deprecated procedure syntax

### DIFF
--- a/project/plugin.sbt
+++ b/project/plugin.sbt
@@ -1,1 +1,2 @@
 scalacOptions ++= Seq("-unchecked", "-deprecation")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.5")

--- a/scalafx-demos/src/main/scala/scalafx/canvas/CanvasDoodleTest.scala
+++ b/scalafx-demos/src/main/scala/scalafx/canvas/CanvasDoodleTest.scala
@@ -86,7 +86,7 @@ object CanvasDoodleTest extends JFXApp {
    *
    * @param color The color to fill
    */
-  private def reset(color: Color) {
+  private def reset(color: Color): Unit = {
     gc.fill = color
     gc.fillRect(0, 0, canvas.width.get, canvas.height.get)
   }

--- a/scalafx-demos/src/main/scala/scalafx/colorselector/ColorSelector.scala
+++ b/scalafx-demos/src/main/scala/scalafx/colorselector/ColorSelector.scala
@@ -63,7 +63,7 @@ object ColorSelector extends JFXApp {
 
   // METHODS - BEGIN
 
-  private def controlSelected(control: SliderControl) {
+  private def controlSelected(control: SliderControl): Unit = {
     if (control.selectedControl.value) {
       synchronizedControls.add(control)
     } else {
@@ -71,14 +71,14 @@ object ColorSelector extends JFXApp {
     }
   }
 
-  private def changeColor() {
+  private def changeColor(): Unit = {
     val newAlphaValue = if (controlAlpha.disabled.value) 1.0 else (controlAlpha.value.toDouble / colorselector.Max)
 
     this.currentColor() = Color.rgb(controlRed.value.toInt, controlGreen.value.toInt,
       controlBlue.value.toInt, newAlphaValue)
   }
 
-  private def synchronizeValues(buffer: ObservableBuffer[SliderControl], changes: Seq[Change[SliderControl]]) {
+  private def synchronizeValues(buffer: ObservableBuffer[SliderControl], changes: Seq[Change[SliderControl]]): Unit = {
     changes.head match {
       case Add(pos, added)      =>
         val media = buffer.map(_.value.value).sum / buffer.size
@@ -91,7 +91,7 @@ object ColorSelector extends JFXApp {
     }
   }
 
-  private def randomizeColors() {
+  private def randomizeColors(): Unit = {
     if (synchronizedControls.nonEmpty) {
       this.synchronizedValue() = math.random * colorselector.Max
     }
@@ -103,22 +103,22 @@ object ColorSelector extends JFXApp {
     }
   }
 
-  private def colorChanged() {
+  private def colorChanged(): Unit = {
     formatColor()
     verifyWebColor()
   }
 
-  private def formatColor() {
+  private def formatColor(): Unit = {
     this.txfColorValue.text() = this.cmbColorFormat.value.value.format(this.currentColor(), !this.chbDisableAlpha.selected.value)
   }
 
   private def getForegroundColor(d: Double) = if (d > Max / 2) Color.Black else Color.White
 
-  private def verifyWebColor() {
+  private def verifyWebColor(): Unit = {
     cmbWebColor.value() = WebColor.colors.find(_.sameColor(currentColor())).orNull
   }
 
-  private def webColorSelected() {
+  private def webColorSelected(): Unit = {
     if (this.cmbWebColor.value.value != null) {
       val color = this.cmbWebColor.value.value.color
       controlRed.value() = doubleToInt(color.red)

--- a/scalafx-demos/src/main/scala/scalafx/colorselector/SliderControl.scala
+++ b/scalafx-demos/src/main/scala/scalafx/colorselector/SliderControl.scala
@@ -52,7 +52,7 @@ class SliderControl(title: String) extends HBox {
 
   def value = this.realValue
 
-  def value_=(d: Double) {
+  def value_=(d: Double): Unit = {
     if (d < Min) {
       value() = Min
     } else if (d > Max) {
@@ -115,7 +115,7 @@ class SliderControl(title: String) extends HBox {
   }
 
 
-  def changeColor(backgroundColor: Color, foregroundColor: Color) {
+  def changeColor(backgroundColor: Color, foregroundColor: Color): Unit = {
     this.cssBackground() = strBackground.format(doubleToInt(backgroundColor.red),
       doubleToInt(backgroundColor.green), doubleToInt(backgroundColor.blue))
     this.cssForeground() = strForeground.format(doubleToInt(foregroundColor.red),

--- a/scalafx-demos/src/main/scala/scalafx/controls/MenuTest.scala
+++ b/scalafx-demos/src/main/scala/scalafx/controls/MenuTest.scala
@@ -77,7 +77,7 @@ object MenuTest extends JFXApp {
     }
   }
 
-  def printEvent(eventStr: String)() {
+  def printEvent(eventStr: String)(): Unit = {
     history.children += new Label(eventStr)
   }
 

--- a/scalafx-demos/src/main/scala/scalafx/controls/SliderTest.scala
+++ b/scalafx-demos/src/main/scala/scalafx/controls/SliderTest.scala
@@ -75,7 +75,7 @@ object SliderTest extends JFXApp {
 
 class SliderControls(target: Slider) extends PropertiesNodes[Slider](target, "Slider Properties") {
 
-  override protected def resetProperties() {
+  override protected def resetProperties(): Unit = {
     target.value = originalValue
     target.blockIncrement = originalBlockIncrement
     txfLabelFormatter.text = null

--- a/scalafx-demos/src/main/scala/scalafx/controls/TextAreaTest.scala
+++ b/scalafx-demos/src/main/scala/scalafx/controls/TextAreaTest.scala
@@ -83,7 +83,7 @@ class TextAreaControls(target: TextArea) extends PropertiesNodes[TextArea](targe
   }
   // In JAvaFX 2.1, bind TextArea.prefColumnCount with value
   chbPrefColumnCount.delegate.selectionModelProperty.addListener(new ChangeListener[Any] {
-    def changed(observable: ObservableValue[_], oldValue: Any, newValue: Any) {
+    def changed(observable: ObservableValue[_], oldValue: Any, newValue: Any): Unit = {
       target.prefColumnCount = newValue.toString.toInt
     }
   })
@@ -93,7 +93,7 @@ class TextAreaControls(target: TextArea) extends PropertiesNodes[TextArea](targe
   }
   // In JAvaFX 2.1, bind TextArea.prefRowCount with value
   chbPrefRowCount.delegate.selectionModelProperty.addListener(new ChangeListener[Any] {
-    def changed(observable: ObservableValue[_], oldValue: Any, newValue: Any) {
+    def changed(observable: ObservableValue[_], oldValue: Any, newValue: Any): Unit = {
       target.prefRowCount = newValue.toString.toInt
     }
   })
@@ -104,7 +104,7 @@ class TextAreaControls(target: TextArea) extends PropertiesNodes[TextArea](targe
   //  chbScrollLeft.delegate.selectionModelProperty.set
   // In JAvaFX 2.1, bind TextArea.prefRowCount with value
   chbPrefRowCount.delegate.selectionModelProperty.addListener(new ChangeListener[Any] {
-    def changed(observable: ObservableValue[_], oldValue: Any, newValue: Any) {
+    def changed(observable: ObservableValue[_], oldValue: Any, newValue: Any): Unit = {
       target.scrollLeft = chbScrollLeft.items.get().get(newValue.toString.toInt)
     }
   })
@@ -114,7 +114,7 @@ class TextAreaControls(target: TextArea) extends PropertiesNodes[TextArea](targe
   }
   // In JAvaFX 2.1, bind TextArea.prefRowCount with value
   chbPrefRowCount.delegate.selectionModelProperty.addListener(new ChangeListener[Any] {
-    def changed(observable: ObservableValue[_], oldValue: Any, newValue: Any) {
+    def changed(observable: ObservableValue[_], oldValue: Any, newValue: Any): Unit = {
       target.scrollTop = chbScrollTop.items.get().get(newValue.toString.toInt)
     }
   })

--- a/scalafx-demos/src/main/scala/scalafx/controls/TooltipDemo.scala
+++ b/scalafx-demos/src/main/scala/scalafx/controls/TooltipDemo.scala
@@ -113,7 +113,7 @@ class TooltipControls(target: Tooltip) extends PropertiesNodes[Tooltip](target, 
     selected <==> target.wrapText
   }
 
-  override protected def resetProperties() {
+  override protected def resetProperties(): Unit = {
     target.contentDisplay = originalContentDisplay
     target.text = originalText
     target.textAlignment = originalTextAlignment

--- a/scalafx-demos/src/main/scala/scalafx/controls/controls/ComboBoxControls.scala
+++ b/scalafx-demos/src/main/scala/scalafx/controls/controls/ComboBoxControls.scala
@@ -37,12 +37,12 @@ class ComboBoxControls(target: ComboBox[String]) extends PropertiesNodes[ComboBo
 
   var itemIndex = 0
 
-  def addNewTab() {
+  def addNewTab(): Unit = {
     itemIndex += 1
     target += "Item %d".format(itemIndex)
   }
 
-  def removeCurrentItem() {
+  def removeCurrentItem(): Unit = {
     target -= target.value.get
   }
 

--- a/scalafx-demos/src/main/scala/scalafx/controls/controls/ControlControls.scala
+++ b/scalafx-demos/src/main/scala/scalafx/controls/controls/ControlControls.scala
@@ -85,7 +85,7 @@ class ControlControls(target: Control) extends PropertiesNodes[Control](target, 
   super.addNode("Width", lblWidth)
   //  super.addNode(btnReset)
 
-  override def resetProperties() {
+  override def resetProperties(): Unit = {
     target.maxHeight = originalMaxHeight.get
     target.prefHeight = originalPrefHeight.get
     target.minHeight = originalMinHeight.get

--- a/scalafx-demos/src/main/scala/scalafx/controls/controls/PropertiesNodes.scala
+++ b/scalafx-demos/src/main/scala/scalafx/controls/controls/PropertiesNodes.scala
@@ -48,7 +48,7 @@ abstract class PropertiesNodes[T](target: T, title: String) extends TitledPane {
 
   private var index = 0
 
-  protected def resetProperties() {}
+  protected def resetProperties(): Unit = {}
 
   protected val btnReset = new Button {
     text = "Reset"
@@ -68,7 +68,7 @@ abstract class PropertiesNodes[T](target: T, title: String) extends TitledPane {
    * @param title Control Node title
    * @param control Control Node
    */
-  protected def addNode(title: String, control: Node) {
+  protected def addNode(title: String, control: Node): Unit = {
     controlsPane.add(new Label {
       font = PropertiesNodes.TitleFont
       labelFor = control
@@ -84,7 +84,7 @@ abstract class PropertiesNodes[T](target: T, title: String) extends TitledPane {
    *
    * @param control Control Node
    */
-  protected def addNode(control: Node) {
+  protected def addNode(control: Node): Unit = {
     controlsPane.add(control, 0, index, 2, 1)
     index += 1
   }
@@ -95,13 +95,13 @@ abstract class PropertiesNodes[T](target: T, title: String) extends TitledPane {
    * @param control1 Control Node 1
    * @param control2 Control Node 2
    */
-  protected def addNodes(control1: Node, control2: Node) {
+  protected def addNodes(control1: Node, control2: Node): Unit = {
     controlsPane.add(control1, 0, index)
     controlsPane.add(control2, 1, index)
     index += 1
   }
 
-  protected def fillDoublePropertyFromText(property: DoubleProperty, field: TextField, cleanAfterAction: Boolean = true, onError: () => Unit = () => ()) {
+  protected def fillDoublePropertyFromText(property: DoubleProperty, field: TextField, cleanAfterAction: Boolean = true, onError: () => Unit = () => ()): Unit = {
     try {
       val txt = field.text.get
       property.value = txt.toDouble
@@ -115,7 +115,7 @@ abstract class PropertiesNodes[T](target: T, title: String) extends TitledPane {
 
   }
 
-  protected def fillIntPropertyFromText(property: IntegerProperty, field: TextField, cleanAfterAction: Boolean = true, onError: () => Unit = () => ()) {
+  protected def fillIntPropertyFromText(property: IntegerProperty, field: TextField, cleanAfterAction: Boolean = true, onError: () => Unit = () => ()): Unit = {
     try {
       val txt = field.text.get
       property.value = txt.toInt

--- a/scalafx-demos/src/main/scala/scalafx/controls/controls/SliderLabelControl.scala
+++ b/scalafx-demos/src/main/scala/scalafx/controls/controls/SliderLabelControl.scala
@@ -46,7 +46,7 @@ class SliderLabelControl(property: DoubleProperty) extends FlowPane {
 
   def this(intProp: IntegerProperty) = this(new DoubleProperty(intProp.getValue, intProp.name) {
     override def value = intProp.value.toDouble
-    override def value_=(v: Double) {
+    override def value_=(v: Double): Unit = {
       intProp.value = v.toInt
     }
   })
@@ -64,42 +64,42 @@ class SliderLabelControl(property: DoubleProperty) extends FlowPane {
     hgrow = Priority.Sometimes
   }
 
-  def blockIncrement_=(v: Double) {
+  def blockIncrement_=(v: Double): Unit = {
     slider.blockIncrement = v
   }
 
-  def pattern_=(v: String) {
+  def pattern_=(v: String): Unit = {
     slider.labelFormatter = new DoubleStringConverter
     lblValue.text <== slider.value.asString(v)
   }
 
-  def majorTickUnit_=(v: Double) {
+  def majorTickUnit_=(v: Double): Unit = {
     slider.majorTickUnit = v
   }
 
   def max = slider.max
-  def max_=(v: Double) {
+  def max_=(v: Double): Unit = {
     slider.max = v
   }
 
   def min = slider.min
-  def min_=(v: Double) {
+  def min_=(v: Double): Unit = {
     slider.min = v
   }
 
-  def minorTickCount_=(v: Int) {
+  def minorTickCount_=(v: Int): Unit = {
     slider.minorTickCount = v
   }
 
-  def showTickLabels_=(v: Boolean) {
+  def showTickLabels_=(v: Boolean): Unit = {
     slider.showTickLabels = v
   }
 
-  def showTickMarks_=(v: Boolean) {
+  def showTickMarks_=(v: Boolean): Unit = {
     slider.showTickMarks = v
   }
 
-  def snapToTicks_=(v: Boolean) {
+  def snapToTicks_=(v: Boolean): Unit = {
     slider.snapToTicks = v
   }
 

--- a/scalafx-demos/src/main/scala/scalafx/controls/controls/TextFieldControls.scala
+++ b/scalafx-demos/src/main/scala/scalafx/controls/controls/TextFieldControls.scala
@@ -43,7 +43,7 @@ class TextFieldControls(target: TextField) extends PropertiesNodes[TextField](ta
   }
   // In JAvaFX 2.1, bind TextArea.prefRowCount with value
   chbPrefColumnCount.delegate.selectionModelProperty.addListener(new ChangeListener[Any] {
-    def changed(observable: ObservableValue[_], oldValue: Any, newValue: Any) {
+    def changed(observable: ObservableValue[_], oldValue: Any, newValue: Any): Unit = {
       target.prefColumnCount = chbPrefColumnCount.items.get().get(newValue.toString.toInt)
     }
   })

--- a/scalafx-demos/src/main/scala/scalafx/controls/tableview/BarChartWithTableViewDemo.scala
+++ b/scalafx-demos/src/main/scala/scalafx/controls/tableview/BarChartWithTableViewDemo.scala
@@ -89,7 +89,7 @@ object BarChartWithTableViewDemo extends JFXApp {
     }
 
 
-  private def showAsTable(name: String, data: ObservableBuffer[Position]) {
+  private def showAsTable(name: String, data: ObservableBuffer[Position]): Unit = {
 
     val tableView = new TableView[Position](data) {
       columns ++= List(

--- a/scalafx-demos/src/main/scala/scalafx/event/MultipleShapeDrawingDemo.scala
+++ b/scalafx-demos/src/main/scala/scalafx/event/MultipleShapeDrawingDemo.scala
@@ -57,7 +57,7 @@ object MultipleShapeDrawingDemo extends JFXApp {
       fill = Color.web("RED", 0.5)
     }
     /** Update the shape using current `start` and `end` points. */
-    override def update() {
+    override def update(): Unit = {
       rectangle.x = math.min(start.x, end.x)
       rectangle.y = math.min(start.y, end.y)
       rectangle.width = math.abs(start.x - end.x)
@@ -71,7 +71,7 @@ object MultipleShapeDrawingDemo extends JFXApp {
       fill = Color.web("GREEN", 0.5)
     }
     /** Update the shape using current `start` and `end` points. */
-    override def update() {
+    override def update(): Unit = {
       ellipse.centerX = start.x
       ellipse.centerY = start.y
       ellipse.radiusX = math.abs(start.x - end.x)
@@ -86,7 +86,7 @@ object MultipleShapeDrawingDemo extends JFXApp {
       strokeWidth = 3
     }
     /** Update the shape using current `start` and `end` points. */
-    override def update() {
+    override def update(): Unit = {
       line.startX = start.x
       line.startY = start.y
       line.endX = end.x
@@ -180,20 +180,20 @@ object MultipleShapeDrawingDemo extends JFXApp {
     private var _end = new Point2D(0, 0)
 
     def start: Point2D = _start
-    def start_=(p: Point2D) {
+    def start_=(p: Point2D): Unit = {
       _start = p
       _end = p
       update()
     }
 
     def end: Point2D = _end
-    def end_=(p: Point2D) {
+    def end_=(p: Point2D): Unit = {
       _end = p
       update()
     }
 
     /** Update the shape using current `start` and `end` points. */
-    def update()
+    def update(): Unit
 
     override def handler: MouseEvent => Unit = {
       me: MouseEvent => {

--- a/scalafx-demos/src/main/scala/scalafx/event/RectangleDrawingDemo.scala
+++ b/scalafx-demos/src/main/scala/scalafx/event/RectangleDrawingDemo.scala
@@ -61,7 +61,7 @@ object RectangleDrawingDemo extends JFXApp {
     }
 
     /** Update location of the rectangle proving two defining point (along the diameter) */
-    def update(start: Point2D = _start, end: Point2D = _end) {
+    def update(start: Point2D = _start, end: Point2D = _end): Unit = {
       _start = start
       _end = end
       rectangle.x = math.min(_start.x, _end.x)

--- a/scalafx-demos/src/main/scala/scalafx/graphics3d/CubeSampleDemo.scala
+++ b/scalafx-demos/src/main/scala/scalafx/graphics3d/CubeSampleDemo.scala
@@ -95,11 +95,11 @@ object CubeSampleDemo extends JFXApp {
     new Group(c, c2, c3)
   }
 
-  def play() {
+  def play(): Unit = {
     animation.play()
   }
 
-  def stop() {
+  def stop(): Unit = {
     animation.pause()
   }
 

--- a/scalafx-demos/src/main/scala/scalafx/graphics3d/PickingDemo.scala
+++ b/scalafx-demos/src/main/scala/scalafx/graphics3d/PickingDemo.scala
@@ -89,7 +89,7 @@ object PickingDemo extends JFXApp {
   }
 
   /** Add mouse interaction to a scene, rotating given node. */
-  private def addMouseInteraction(scene: Scene, group: Group) {
+  private def addMouseInteraction(scene: Scene, group: Group): Unit = {
     val angleY = DoubleProperty(-50)
     val yRotate = new Rotate {
       angle <== angleY

--- a/scalafx-demos/src/main/scala/scalafx/graphics3d/SphereAndBoxDemo.scala
+++ b/scalafx-demos/src/main/scala/scalafx/graphics3d/SphereAndBoxDemo.scala
@@ -87,7 +87,7 @@ object SphereAndBoxDemo extends JFXApp {
   }
 
   /** Add mouse interaction to a scene, rotating given node. */
-  private def addMouseInteraction(scene: Scene, node: Node) {
+  private def addMouseInteraction(scene: Scene, node: Node): Unit = {
     val angleY = DoubleProperty(-50)
     val yRotate = new Rotate {
       angle <== angleY

--- a/scalafx-demos/src/main/scala/scalafx/graphics3d/TriangleMeshDemo.scala
+++ b/scalafx-demos/src/main/scala/scalafx/graphics3d/TriangleMeshDemo.scala
@@ -194,7 +194,7 @@ object TriangleMeshDemo extends JFXApp {
   }
 
   /** Add mouse interaction to a scene, rotating given node. */
-  private def addMouseInteraction(scene: Scene, node: Node) {
+  private def addMouseInteraction(scene: Scene, node: Node): Unit = {
     val angleY = DoubleProperty(0)
     val yRotate = new Rotate {
       angle <== angleY

--- a/scalafx-demos/src/main/scala/scalafx/graphics3d/VideoCubeDemo.scala
+++ b/scalafx-demos/src/main/scala/scalafx/graphics3d/VideoCubeDemo.scala
@@ -155,12 +155,12 @@ object VideoCubeDemo extends JFXApp {
     new Group(c1)
   }
 
-  def play() {
+  def play(): Unit = {
     animation.play()
     for (mp <- mediaPlayers) {mp.play()}
   }
 
-  def stop() {
+  def stop(): Unit = {
     animation.pause()
     for (mp <- mediaPlayers) {mp.stop()}
   }
@@ -279,7 +279,7 @@ class VideoCube(val mediaPlayers: List[MediaPlayer], size: Double) extends Group
     children = Seq(backRect, mediaView, debugText)
 
     def fitHeight = mediaView.fitHeightProperty
-    def fitHeight_=(v: Double) {
+    def fitHeight_=(v: Double): Unit = {
       fitHeight() = v
       backRect.height = v
       mediaView.layoutY = v / 4
@@ -291,24 +291,24 @@ class VideoCube(val mediaPlayers: List[MediaPlayer], size: Double) extends Group
      * necessary to fit.
      */
     def fitWidth = mediaView.fitWidthProperty
-    def fitWidth_=(v: Double) {
+    def fitWidth_=(v: Double): Unit = {
       fitWidth() = v
       backRect.width = v
       debugText.layoutX = v / 4
     }
 
     def preserveRatio = mediaView.preserveRatioProperty
-    def preserveRatio_=(v: Boolean) {
+    def preserveRatio_=(v: Boolean): Unit = {
       preserveRatio() = v
     }
 
     def smooth = mediaView.smoothProperty
-    def smooth_=(v: Boolean) {
+    def smooth_=(v: Boolean): Unit = {
       smooth() = v
     }
 
     def text = debugText.text
-    def text_=(v: String) {
+    def text_=(v: String): Unit = {
       debugText.text = v
     }
 

--- a/scalafx-demos/src/main/scala/scalafx/imaginej/JumpingFrogsPuzzle.scala
+++ b/scalafx-demos/src/main/scala/scalafx/imaginej/JumpingFrogsPuzzle.scala
@@ -364,7 +364,7 @@ class View(position: FrogShape => Int, val frogShapes: List[FrogShape]) {
 // control
 //
 class Control {
-  def update(model: Model, view: View) {
+  def update(model: Model, view: View): Unit = {
     view.frogShapes.foreach {
       case `theDummyFrogShape` =>
       case frogShape           => frogShape.onMouseClicked = {

--- a/scalafx-demos/src/main/scala/scalafx/imaginej/ScalaFX_Collections_01.scala
+++ b/scalafx-demos/src/main/scala/scalafx/imaginej/ScalaFX_Collections_01.scala
@@ -52,44 +52,44 @@ import scalafx.collections.ObservableBuffer.{Add, Remove, Reorder}
  */
 
 object ScalaFX_Collections_01 {
-  private def changes01(observableStringBuffer: ObservableBuffer[String]) {
+  private def changes01(observableStringBuffer: ObservableBuffer[String]): Unit = {
     println("observable string buffer before changes01 " + observableStringBuffer)
     observableStringBuffer += "a"
     observableStringBuffer += "b"
     println("observable string buffer after  changes01 " + observableStringBuffer)
   }
 
-  private def changes02(observableStringBuffer: ObservableBuffer[String]) {
+  private def changes02(observableStringBuffer: ObservableBuffer[String]): Unit = {
     println("observable string buffer before changes02 " + observableStringBuffer)
     observableStringBuffer ++= List("c", "d")
     println("observable string buffer after  changes02 " + observableStringBuffer)
   }
 
-  private def changes03(observableStringBuffer: ObservableBuffer[String]) {
+  private def changes03(observableStringBuffer: ObservableBuffer[String]): Unit = {
     println("observable string buffer before changes03 " + observableStringBuffer)
     List("x", "y", "z") ++=: observableStringBuffer
     println("observable string buffer after  changes03 " + observableStringBuffer)
   }
 
-  private def changes04(observableStringBuffer: ObservableBuffer[String]) {
+  private def changes04(observableStringBuffer: ObservableBuffer[String]): Unit = {
     println("observable string buffer before changes04 " + observableStringBuffer)
     observableStringBuffer.remove(1, 4)
     println("observable string buffer after  changes04 " + observableStringBuffer)
   }
 
-  private def changes05(observableStringBuffer: ObservableBuffer[String]) {
+  private def changes05(observableStringBuffer: ObservableBuffer[String]): Unit = {
     println("observable string buffer before changes05 " + observableStringBuffer)
     observableStringBuffer.setAll("X", "C", "D")
     println("observable string buffer after  changes05 " + observableStringBuffer)
   }
 
-  private def changes06(observableStringBuffer: ObservableBuffer[String]) {
+  private def changes06(observableStringBuffer: ObservableBuffer[String]): Unit = {
     println("observable string buffer before changes06 " + observableStringBuffer)
     observableStringBuffer.sort()
     println("observable string buffer after  changes06 " + observableStringBuffer)
   }
 
-  def main(args: Array[String]) {
+  def main(args: Array[String]): Unit = {
     val observableStringBuffer = ObservableBuffer[String]()
     observableStringBuffer onInvalidate {
       println("observable string buffer invalidated")

--- a/scalafx-demos/src/main/scala/scalafx/imaginej/ScalaFX_Properties_And_Binding_01.scala
+++ b/scalafx-demos/src/main/scala/scalafx/imaginej/ScalaFX_Properties_And_Binding_01.scala
@@ -51,7 +51,7 @@ import scalafx.beans.property.DoubleProperty
  */
 
 object ScalaFX_Properties_And_Binding_01 {
-  def main(args: Array[String]) {
+  def main(args: Array[String]): Unit = {
     val bill = new Bill(new DoubleProperty(null, "Bill"))
     bill.amountDue onChange {
       (_, oldAmountDue, newAmountDue) =>

--- a/scalafx-demos/src/main/scala/scalafx/imaginej/ScalaFX_Properties_And_Binding_02.scala
+++ b/scalafx-demos/src/main/scala/scalafx/imaginej/ScalaFX_Properties_And_Binding_02.scala
@@ -52,7 +52,7 @@ import scalafx.beans.property.IntegerProperty
  */
 
 object ScalaFX_Properties_And_Binding_02 {
-  def main(args: Array[String]) {
+  def main(args: Array[String]): Unit = {
     val num1 = new IntegerProperty(null, "num1")
     val num2 = new IntegerProperty(null, "num2")
     val sum: NumberBinding = num1 + num2

--- a/scalafx-demos/src/main/scala/scalafx/imaginej/ScalaFX_Properties_And_Binding_03.scala
+++ b/scalafx-demos/src/main/scala/scalafx/imaginej/ScalaFX_Properties_And_Binding_03.scala
@@ -53,7 +53,7 @@ import scalafx.beans.property.IntegerProperty
  */
 
 object ScalaFX_Properties_And_Binding_03 {
-  def main(args: Array[String]) {
+  def main(args: Array[String]): Unit = {
     val num1 = new IntegerProperty(null, "num1")
     val num2 = new IntegerProperty(null, "num2")
     val max = Bindings.max(num1, num2)

--- a/scalafx-demos/src/main/scala/scalafx/imaginej/ScalaFX_Properties_And_Binding_04.scala
+++ b/scalafx-demos/src/main/scala/scalafx/imaginej/ScalaFX_Properties_And_Binding_04.scala
@@ -54,7 +54,7 @@ import scalafx.beans.property.IntegerProperty
  */
 
 object ScalaFX_Properties_And_Binding_04 {
-  def main(args: Array[String]) {
+  def main(args: Array[String]): Unit = {
     val num1 = new IntegerProperty(null, "num1")
     val num2 = new IntegerProperty(null, "num2")
     val num3 = new IntegerProperty(null, "num3")

--- a/scalafx-demos/src/main/scala/scalafx/imaginej/ScalaFX_Properties_And_Binding_05.scala
+++ b/scalafx-demos/src/main/scala/scalafx/imaginej/ScalaFX_Properties_And_Binding_05.scala
@@ -53,7 +53,7 @@ import scalafx.beans.property.DoubleProperty
  */
 
 object ScalaFX_Properties_And_Binding_05 {
-  def main(args: Array[String]) {
+  def main(args: Array[String]): Unit = {
     val bill1 = new Bill(new DoubleProperty(null, "Bill 1"))
     val bill2 = new Bill(new DoubleProperty(null, "Bill 2"))
     val bill3 = new Bill(new DoubleProperty(null, "Bill 3"))


### PR DESCRIPTION
  This gets rid of 1281 warnings
  (done by running `scalafxDemos/scalafix ProcedureSyntax` through sbt)

closes #308