### PR TITLE
Update Color.scala

### DIFF
--- a/scalafx/src/main/scala/scalafx/scene/paint/Color.scala
+++ b/scalafx/src/main/scala/scalafx/scene/paint/Color.scala
@@ -90,12 +90,12 @@ object Color {
   /**
    * This is a shortcut for rgb(gray, gray, gray).
    */
-  def grayRgb(gray: Int) = new Color(jfxsp.Color.gray(gray))
+  def grayRgb(gray: Int) = new Color(jfxsp.Color.grayRgb(gray))
 
   /**
    * This is a shortcut for rgb(gray, gray, gray, opacity).
    */
-  def grayRgb(gray: Int, opacity: Double) = new Color(jfxsp.Color.gray(gray, opacity))
+  def grayRgb(gray: Int, opacity: Double) = new Color(jfxsp.Color.grayRgb(gray, opacity))
 
   /**
    * Creates a color value from a string representation.  The format of the string representation is the same as in web(String).

--- a/scalafx/src/main/scala/scalafx/scene/paint/Color.scala
+++ b/scalafx/src/main/scala/scalafx/scene/paint/Color.scala
@@ -632,3 +632,4 @@ class Color(override val delegate: jfxsp.Color) extends Paint(delegate) with SFX
   def saturate: Color = delegate.saturate
 
 }
+


### PR DESCRIPTION
SFX Color.grayRgb is used to wrap the grayRgb method in JavaFX. Unlike JFX's gray method, grayRgb is of type Int and has a range of 0 - 255, which corresponds to 0.0 - 1.0 of the Double type of gray. The current SFX delegates grayRgb directly to gray, and the Int type is converted and automatically converted to Double, which is wrong and cannot be checked by the checkRGB method.