### PR TITLE
Support for JavaFX 17

### DIFF
--- a/scalafx/src/main/scala/scalafx/application/Platform.scala
+++ b/scalafx/src/main/scala/scalafx/application/Platform.scala
@@ -30,6 +30,7 @@ package scalafx.application
 import javafx.{application => jfxa}
 import scalafx.Includes._
 import scalafx.beans.property.ReadOnlyBooleanProperty
+import scalafx.scene.input.KeyCode
 
 import scala.language.implicitConversions
 
@@ -203,6 +204,29 @@ object Platform {
    * @since 9
    */
   def exitNestedEventLoop(key: Any, rval: Any): Unit = jfxa.Platform.exitNestedEventLoop(key, rval)
+
+  /**
+   * Returns a flag indicating whether the key corresponding to {{{keyCode}}}
+   * is in the locked (or "on") state.
+   * {{{keyCode}}} must be one of: [[KeyCode.CAPS]] or [[KeyCode.NUM_LOCK]].
+   * If the underlying system is not able to determine the state of the
+   * specified {{{keyCode}}}, {{{None}}} is returned.
+   * If the keyboard attached to the system doesn't have the specified key,
+   * an {{{Some[False]}}} is returned.
+   * This method must be called on the JavaFX Application thread.
+   *
+   * @param keyCode the {{{keyCode}}} of the lock state to query
+   * @return the lock state of the key corresponding to {{{keyCode}}},
+   *         or None if the system cannot determine its state
+   * @throws IllegalArgumentException if {{{keyCode}}} is not one of the
+   *                                  valid{{{keyCode}}} values
+   * @throws IllegalStateException    if this method is called on a thread
+   *                                  other than the JavaFX Application Thread
+   * @since 17
+   */
+  def isKeyLocked(keyCode: KeyCode): Option[Boolean] = if (jfxa.Platform.isKeyLocked(keyCode).isPresent) {
+    Some(jfxa.Platform.isKeyLocked(keyCode).get)
+  } else None
 
   /**
    * Checks whether a nested event loop is running, returning true to indicate

--- a/scalafx/src/main/scala/scalafx/print/JobSettings.scala
+++ b/scalafx/src/main/scala/scalafx/print/JobSettings.scala
@@ -73,6 +73,50 @@ final class JobSettings(override val delegate: jfxp.JobSettings)
   }
 
   /**
+   * A {{{ StringProperty }}} representing the
+   * name of a filesystem file, to which the platform printer
+   * driver should spool the rendered print data.
+   * <p>
+   * Applications can use this to programmatically request print-to-file
+   * behavior where the native print system is capable of spooling the
+   * output to a filesystem file, rather than the printer device.
+   * <p>
+   * This is often useful where the printer driver generates a format
+   * such as Postscript or PDF, and the application intends to distribute
+   * the result instead of printing it, or for some other reason the
+   * application does not want physical media (paper) emitted by the printer.
+   * <p>
+   * The default value is an empty string, which is interpreted as unset,
+   * equivalent to null, which means output is sent to the printer.
+   * So in order to reset to print to the printer, clear the value of
+   * this property by setting it to null or an empty string.
+   * <p>
+   * Additionally if the application displays a printer dialog which allows
+   * the user to specify a file destination, including altering an application
+   * specified file destination, the value of this property will reflect that
+   * user-specified choice, including clearing it to reset to print to
+   * the printer, if the user does so.
+   * <p>
+   * If the print system does not support print-to-file, then this
+   * setting will be ignored.
+   * <p>
+   * If the specified name specifies a non-existent path, or does not specify
+   * a user writable file, when printing the results are platform-dependent.
+   * Possible behaviours might include replacement with a default output file location,
+   * printing to the printer instead, or a platform printing error.
+   * If a {{{ SecurityManager }}} is installed and it denies access to the
+   * specified file a {{{ SecurityException }}} may be thrown.
+   *
+   * @return the name of a printer spool file
+   * @since 17
+   */
+  def outputFile: StringProperty = delegate.outputFileProperty
+
+  def outputFile_=(v: String = ""): Unit = {
+    outputFile() = v
+  }
+
+  /**
    * IntegerProperty representing the number of copies of the job to print.
    */
   def copies: IntegerProperty = delegate.copiesProperty

--- a/scalafx/src/main/scala/scalafx/scene/SpotLight.scala
+++ b/scalafx/src/main/scala/scalafx/scene/SpotLight.scala
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2011-2021, ScalaFX Project
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the ScalaFX Project nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE SCALAFX PROJECT OR ITS CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package scalafx.scene
+
+import javafx.{geometry => jfxg, scene => jfxs}
+import scalafx.Includes._
+import scalafx.beans.property.{DoubleProperty, ObjectProperty}
+import scalafx.delegate.SFXDelegate
+import scalafx.geometry.Point3D
+import scalafx.scene.paint.Color
+
+import scala.language.implicitConversions
+
+object SpotLight {
+  implicit def sfxSpotLight2jfx(sl: SpotLight): jfxs.SpotLight = if (sl != null) sl.delegate else null
+}
+
+/**
+ * A {{{SpotLight}}} is a {{PointLight}}} that radiates light in a cone in a specific direction.
+ * The direction is defined by the [[directionProperty()]] direction vector property of the light. The direction
+ * can be rotated by setting a rotation transform on the {{{SpotLight}}}. For example, if the direction vector is
+ * {{{(1, 1, 1)}}} and the light is not rotated, it will point in the {{{(1, 1, 1)}}} direction, and if the light is
+ * rotated 90 degrees on the y axis, it will point in the {{{(1, 1, -1)}}} direction.
+ * <p>
+ * In addition to the factors that control the light intensity of a {{{PointLight}}}, a {{{SpotLight}}} has a
+ * light-cone attenuation factor, {{{spot}}}, that is determined by 3 properties:
+ * <ul>
+ * <li> [[innerAngleProperty]] innerAngle: the angle of the inner cone (see image below)
+ * <li> [[outerAngleProperty]] outerAngle: the angle of the outer cone (see image below)
+ * <li> [[falloffProperty]] falloff: the factor that controls the light's intensity drop inside the outer cone
+ * </ul>
+ * The valid ranges for these properties are {{{0 <= innerAngle <= outerAngle <= 180}}} and {{{falloff >= 0}}};
+ * values outside either of these ranges can produce unexpected results.
+ * <p>
+ * The angle of a point to the light is defined as the angle between its vector to the light's position and the
+ * direction of the light. For such an angle {{{theta}}}, if
+ * <ul>
+ * <li>{{{theta < innerAngle}}} then {{{spot = 1}}}
+ * <li>{{{theta > outerAngle}}} then {{{spot = 0}}}
+ * <li>{{{innerAngle <= theta <= outerAngle}}} then
+ *
+ * <pre>spot = pow((cos(theta) - cos(outer)) / (cos(inner) - cos(outer)), falloff)</pre>
+ *
+ * which represents a drop in intensity from the inner angle to the outer angle.
+ * </ul>
+ * As a result, {{{0 <= spot <= 1}}}. The overall intensity of the light is {{{I = lambert * atten * spot}}}.
+ * <p>
+ * <img src="doc-files/spotlight.png" alt="Image of the Spotlight">
+ *
+ * @since 17
+ * @see PhongMaterial
+ */
+class SpotLight(override val delegate: jfxs.SpotLight = new jfxs.SpotLight())
+  extends LightBase(delegate)
+  with SFXDelegate[jfxs.SpotLight] {
+
+  /** Creates a new instance of `SpotLight` class using the specified color. */
+  def this(color: Color) = this(new jfxs.SpotLight(color))
+
+  /**
+   * The direction vector of the spotlight. It can be rotated by setting a rotation transform on the
+   * {{{SpotLight}}}. The vector need not be normalized.
+   */
+  def direction: ObjectProperty[jfxg.Point3D] = delegate.directionProperty
+
+  def direction_(p: Point3D = new Point3D(0, 0, 1)): Unit = {
+    direction() = p
+  }
+
+  /**
+   * The angle of the spotlight's inner cone, in degrees. A point whose angle to the light is less than this angle is
+   * not attenuated by the spotlight factor ({{{spot = 1}}}). At larger angles, the light intensity starts to drop.
+   * See the class doc for more information.
+   * <p>
+   * The valid range is {{{0 <= innerAngle <= outerAngle}}}; values outside of this range can produce unexpected
+   * results.
+   */
+  def innerAngle: DoubleProperty = delegate.innerAngleProperty
+
+  def innerAngle_(v: Double): Unit = {
+    innerAngle() = v
+  }
+
+  /**
+   * The angle of the spotlight's outer cone, in degrees (as shown in the class doc image). A point whose angle to the
+   * light is greater than this angle receives no light ({{{spot = 0}}}). A point whose angle to the light is less
+   * than the outer angle but greater than the inner angle receives partial intensity governed by the falloff factor.
+   * See the class doc for more information.
+   * <p>
+   * The valid range is {{{innerAngle <= outerAngle <= 180}}}; values outside of this range can produce unexpected
+   * results.
+   */
+  def outerAngle: DoubleProperty = delegate.outerAngleProperty
+
+  def outerAngle_(v: Double): Unit = {
+    outerAngle() = v
+  }
+
+  /**
+   * The intensity falloff factor of the spotlight's outer cone. A point whose angle to the light is
+   * greater than the inner angle but less than the outer angle receives partial intensity governed by this factor.
+   * The larger the falloff, the sharper the drop in intensity from the inner cone. A falloff factor of 1 gives a
+   * linear drop in intensity, values greater than 1 give a convex drop, and values smaller than 1 give a concave
+   * drop. See the class doc for more information.
+   * <p>
+   * The valid range is {{{0 <= falloff}}}; values outside of this range can produce unexpected results.
+   */
+  def falloff: DoubleProperty = delegate.falloffProperty
+
+  def falloff_(v: Double): Unit = {
+    falloff() = v
+  }
+}

--- a/scalafx/src/main/scala/scalafx/scene/control/TreeTableCell.scala
+++ b/scalafx/src/main/scala/scalafx/scene/control/TreeTableCell.scala
@@ -102,8 +102,23 @@ class TreeTableCell[S, T](override val delegate: jfxsc.TreeTableCell[S, T] = new
    *
    * @see $URL0#updateTreeTableRow-javafx.scene.control.TreeTableRow- $ORIGINALDOC
    */
+  @deprecated("Use updateTableRow instead", since = "17")
   def updateTreeTableRow(treeTableRow: TreeTableRow[S]): Unit = {
-    delegate.updateTreeTableRow(treeTableRow)
+    updateTableRow(treeTableRow)
+  }
+
+  /**
+   * Updates the {{{TreeTableRow}}} associated with this {{{TreeTableCell}}}.
+   * <p>
+   * Note: This function is intended to be used by experts, primarily
+   * by those implementing new Skins. It is not common
+   * for developers or designers to access this function directly.
+   *
+   * @param row the {{{TreeTableRow}}} associated with this {{{TreeTableCell}}}
+   * @since 17
+   */
+  def updateTableRow(row: TreeTableRow[S]): Unit = {
+    delegate.updateTableRow(row)
   }
 
   /**
@@ -111,8 +126,23 @@ class TreeTableCell[S, T](override val delegate: jfxsc.TreeTableCell[S, T] = new
    *
    * @see $URL0#updateTreeTableColumn-javafx.scene.control.TreeTableColumn- $ORIGINALDOC
    */
+  @deprecated("Use updateTableColumn instead", since = "17")
   def updateTreeTableColumn(col: TreeTableColumn[S, T]): Unit = {
-    delegate.updateTreeTableColumn(col)
+    updateTableColumn(col)
+  }
+
+  /**
+   * Updates the {{{TreeTableColumn}}} associated with this {{{TreeTableCell}}}.
+   * <p>
+   * Note: This function is intended to be used by experts, primarily
+   * by those implementing new Skins. It is not common
+   * for developers or designers to access this function directly.
+   *
+   * @param column the {{{TreeTableColumn}}} associated with this {{{TreeTableCell}}}
+   * @since 17
+   */
+  def updateTableColumn(column: TreeTableColumn[S, T]): Unit = {
+    delegate.updateTableColumn(column)
   }
 
 }


### PR DESCRIPTION
This closes #362.

More in details,

```
➤ rg "@since 17" -c ./modules/javafx.* -g '!*module-info.java'
./modules/javafx.graphics/src/main/java/javafx/scene/SpotLight.java:1 → now wrapped
./modules/javafx.graphics/src/main/java/javafx/print/JobSettings.java:1 → added
./modules/javafx.graphics/src/main/java/javafx/css/Stylesheet.java:1 → ignored, as we don't wrap this class yet
./modules/javafx.graphics/src/main/java/javafx/application/Platform.java:1 → added
./modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableCell.java:3 → handled the 2 deprecations, don't know what to do about `registerInvalidationListener`
./modules/javafx.controls/src/main/java/javafx/scene/control/SkinBase.java:4 → ignored `registerInvalidationListener`, `unregisterInvalidationListeners`, `registerListChangeListener`, `unregisterListChangeListeners`
```