### PR TITLE
Fix NPEs in TableColumn, TreeTableColumn & Stage

### DIFF
--- a/scalafx/src/main/scala/scalafx/scene/control/TableColumn.scala
+++ b/scalafx/src/main/scala/scalafx/scene/control/TableColumn.scala
@@ -317,7 +317,7 @@ class TableColumn[S, T](override val delegate: jfxsc.TableColumn[S, T] = new jfx
   def cellValueFactory_=(f: TableColumn.CellDataFeatures[S, T] => ObservableValue[T, T]): Unit = {
     delegate.cellValueFactoryProperty.setValue(new jfxu.Callback[jfxsc.TableColumn.CellDataFeatures[S, T], jfxbv.ObservableValue[T]] {
       def call(v: jfxsc.TableColumn.CellDataFeatures[S, T]): jfxbv.ObservableValue[T] = {
-        f(v).delegate
+        Option(f(v)).map(_.delegate).orNull
       }
     })
   }

--- a/scalafx/src/main/scala/scalafx/scene/control/TreeTableColumn.scala
+++ b/scalafx/src/main/scala/scalafx/scene/control/TreeTableColumn.scala
@@ -423,7 +423,7 @@ class TreeTableColumn[S, T](override val delegate: jfxsc.TreeTableColumn[S, T] =
     delegate.cellValueFactoryProperty.setValue(
       new jfxu.Callback[jfxsc.TreeTableColumn.CellDataFeatures[S, T], jfxbv.ObservableValue[T]] {
         def call(v: jfxsc.TreeTableColumn.CellDataFeatures[S, T]): jfxbv.ObservableValue[T] = {
-          f(v).delegate
+          Option(f(v)).map(_.delegate).orNull
         }
       }
     )

--- a/scalafx/src/main/scala/scalafx/stage/Stage.scala
+++ b/scalafx/src/main/scala/scalafx/stage/Stage.scala
@@ -142,7 +142,7 @@ class Stage(override val delegate: jfxs.Stage = new jfxs.Stage)
    * Specify the scene to be used on this stage.
    */
   def scene_=(s: Scene): Unit = {
-    delegate.setScene(s.delegate)
+    delegate.setScene(Option(s).map(_.delegate).orNull)
   }
 
   /**

--- a/scalafx/src/test/scala/scalafx/scene/control/TableColumnSpec.scala
+++ b/scalafx/src/test/scala/scalafx/scene/control/TableColumnSpec.scala
@@ -53,10 +53,17 @@ class TableColumnSpec[S, T]
     val nameTC = new TableColumn[String, String]("Name")
     nameTC.columns.size should (equal(0))
 
-    nameTC.columns +=(firstTC, lastTC)
+    nameTC.columns.addAll(firstTC, lastTC)
     nameTC.columns.size should (equal(2))
 
     nameTC.columns.clear()
     nameTC.columns.size should (equal(0))
+  }
+
+  it should "allow a cellValueFactory to return null" in {
+    val tc = new TableColumn[String, String]("col") {
+      cellValueFactory = { _cdf => null }
+    }
+    tc.cellValueFactory()(null)
   }
 }

--- a/scalafx/src/test/scala/scalafx/scene/control/TreeTableColumnSpec.scala
+++ b/scalafx/src/test/scala/scalafx/scene/control/TreeTableColumnSpec.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2011-2021, ScalaFX Project
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the ScalaFX Project nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE SCALAFX PROJECT OR ITS CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package scalafx.scene.control
+
+import javafx.scene.{control => jfxsc}
+import org.scalatest.matchers.should.Matchers._
+import scalafx.Includes._
+import scalafx.testutil.SimpleSFXDelegateSpec
+
+/**
+ * TreeTableColumnSpec tests.
+ */
+class TreeTableColumnSpec[S, T]
+    extends SimpleSFXDelegateSpec[jfxsc.TreeTableColumn[S, T], TreeTableColumn[S, T]](
+      classOf[jfxsc.TreeTableColumn[S, T]],
+      classOf[TreeTableColumn[S, T]]
+    ) {
+
+  it should "allow a cellValueFactory to return null" in {
+    val tc = new TreeTableColumn[String, String]("col") {
+      cellValueFactory = { _cdf => null }
+    }
+    tc.cellValueFactory()(null)
+  }
+}

--- a/scalafx/src/test/scala/scalafx/stage/StageSpec.scala
+++ b/scalafx/src/test/scala/scalafx/stage/StageSpec.scala
@@ -34,9 +34,14 @@ import scalafx.testutil.{RunOnApplicationThread, SimpleSFXDelegateSpec}
 
 /**
  * Stage Spec tests.
- *
- *
  */
 class StageSpec
   extends SimpleSFXDelegateSpec[jfxs.Stage, Stage](classOf[jfxs.Stage], classOf[Stage])
-  with RunOnApplicationThread
+  with RunOnApplicationThread {
+
+  it should "allow scene to be set to null" in {
+    new Stage() {
+      scene = null
+    }
+  }
+}


### PR DESCRIPTION
These NPEs happens when calling delegate on an argument that can be null.
Tests included.

Close #371 