### PR TITLE
fixes for #410

### DIFF
--- a/scalafx-demos/src/main/scala/scalafx/controls/ControlsTest.scala
+++ b/scalafx-demos/src/main/scala/scalafx/controls/ControlsTest.scala
@@ -47,7 +47,7 @@ object ControlsTest extends JFXApp3 {
       right = controlsPane
     }
     stage = new JFXApp3.PrimaryStage {
-      title = "CheckBox Test"
+      title = "Controls Test"
       width = 800
       height = 600
       scene = new Scene { content = mainContent }

--- a/scalafx-demos/src/main/scala/scalafx/controls/TextAreaTest.scala
+++ b/scalafx-demos/src/main/scala/scalafx/controls/TextAreaTest.scala
@@ -39,13 +39,14 @@ import scalafx.scene.layout.{BorderPane, Priority, VBox}
 import scalafx.scene.paint.Color
 
 object TextAreaTest extends JFXApp3 {
+  private val initialPreferredHeight: Int = 380
   override def start(): Unit = {
     lazy val textArea = new TextArea { prefColumnCount = 20 }
     val controlsPane = new VBox {
       spacing = 5
       fillWidth = true
       alignment = Pos.Center
-      prefHeight <== stage.scene().height
+      prefHeight <== initialPreferredHeight
       hgrow = Priority.Never
       children =
         List(new TextAreaControls(textArea), new TextInputControlControls(textArea), new ControlControls(textArea))
@@ -57,12 +58,13 @@ object TextAreaTest extends JFXApp3 {
     stage = new JFXApp3.PrimaryStage {
       title = "TextArea Test"
       width = 450
-      height = 380
+      height = initialPreferredHeight
       scene = new Scene {
         fill = Color.LightGray
         content = mainPane
       }
     }
+    controlsPane.prefHeight <== stage.scene().height
   }
 }
 

--- a/scalafx-demos/src/main/scala/scalafx/event/MultipleShapeDrawingDemo.scala
+++ b/scalafx-demos/src/main/scala/scalafx/event/MultipleShapeDrawingDemo.scala
@@ -125,7 +125,12 @@ object MultipleShapeDrawingDemo extends JFXApp3 {
             var mouseHandlerSubscription: Option[Subscription] = None
             alignToggleGroup.selectedToggle.onChange {
               mouseHandlerSubscription.foreach(_.cancel())
-              val handlerId = alignToggleGroup.selectedToggle().asInstanceOf[javafx.scene.control.ToggleButton].id()
+              val handlerId = alignToggleGroup.selectedToggle() match {
+                case tb: javafx.scene.control.ToggleButton =>
+                  tb.id()
+                case null =>
+                  "rectangle" // default, if none selected
+              }
               val selectedHandler = handlerId match {
                 case "rectangle" =>
                   Option(RectangleInteractor.handler)

--- a/scalafx-demos/src/main/scala/scalafx/imaginej/JumpingFrogsPuzzle.scala
+++ b/scalafx-demos/src/main/scala/scalafx/imaginej/JumpingFrogsPuzzle.scala
@@ -209,7 +209,7 @@ class Model(var optionalFrogMap: Map[Int, Option[Frog]]) {
 
   private def positionSingleton(frog: Frog) =
     for {
-      (i, Some(`frog`)) <- optionalFrogMap
+      case (i, Some(`frog`)) <- optionalFrogMap
     } yield i
 
   private def update(next: Int => Int) = (frog: Frog) => {

--- a/scalafx/src/test/scala/issues/issue16/Issue16Spec.scala
+++ b/scalafx/src/test/scala/issues/issue16/Issue16Spec.scala
@@ -54,7 +54,7 @@ class Issue16Spec extends AnyFlatSpec {
 
     // TODO Scala 3: Original line of code does not compile with Scala 3.0.0-RC2
     // fill <== when (hover) choose Color.Green otherwise Color.Red
-    // NOTE Scala 3: variable `helper` was added to force type (and implicint conversions) on right side of `<==`
+    // NOTE Scala 3: variable `helper` was added to force type (and implicit conversions) on right side of `<==`
     //               This is not needed in Scala 2
     import javafx.scene.{paint => jfxsp}
     import scalafx.beans.binding.ObjectBinding


### PR DESCRIPTION
While testing `scalafx-demos` with scala3, 3 demos had problems:

- 2 demos encountered NullPointerErrors errors
- compile error occurred with the `JumpingFrogsPuzzle` demo

See #410 for a description of NPE errors with stackdumps.
See below for the `JumpingFrogsPuzzle`.

This PR eliminates both NullPointerExceptions:

[TextAreaTest.scala](https://github.com/scalafx/scalafx/blob/9d55921ad7ee1a6cdf72fcc222e45d52b5d3880c/scalafx-demos/src/main/scala/scalafx/controls/TextAreaTest.scala)
 [MultipleShapeDrawingDemo.scala](https://github.com/scalafx/scalafx/blob/9d55921ad7ee1a6cdf72fcc222e45d52b5d3880c/scalafx-demos/src/main/scala/scalafx/event/MultipleShapeDrawingDemo.scala)

Note that the MultipleShapeDrawingDemo NPE only occurs if you click on the Rectangle immediately after startup.

Other changes:
Corrected a mispelling of 'implicit' in a comment of [Issue16Spec.scala](https://github.com/scalafx/scalafx/blob/9d55921ad7ee1a6cdf72fcc222e45d52b5d3880c/scalafx/src/test/scala/issues/issue16/Issue16Spec.scala#L57C1-L57C114)

Made changes suggested by scala3 compiler (added `case` to an expression) for the [JumpingFrogsPuzzle](https://github.com/scalafx/scalafx/blob/9d55921ad7ee1a6cdf72fcc222e45d52b5d3880c/scalafx-demos/src/main/scala/scalafx/imaginej/JumpingFrogsPuzzle.scala#L212)

This makes all 100 or so demos compatible with `scala3`.


